### PR TITLE
Resolving the 429 rate limit issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A local account with Admin privileges to the network application. Must not be a 
 
 ## Installation
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=sirkirby&repository=unifi-network-rules&category=integration) [Coming Soon](https://github.com/hacs/default/pull/2732)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=sirkirby&repository=unifi-network-rules&category=integration)
 
 OR
 

--- a/custom_components/unifi_network_rules/manifest.json
+++ b/custom_components/unifi_network_rules/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "local_polling",    
     "issue_tracker": "https://github.com/sirkirby/unifi-network-rules/issues",
     "requirements": ["aiohttp"],
-    "version": "1.0.2"
+    "version": "1.1.0"
 }


### PR DESCRIPTION
Added handling of the 429 rate limit error along with some backoff retry logic to avoid overwhelming the UDM and preventing 429 errors.

fixes #15 