### PR TITLE
Quality of Service rule support

### DIFF
--- a/custom_components/unifi_network_rules/__init__.py
+++ b/custom_components/unifi_network_rules/__init__.py
@@ -369,6 +369,9 @@ async def async_create_entity(hass: HomeAssistant, rule_type: str, rule: Any) ->
         elif rule_type == "wlans":
             from .switch import UnifiWlanSwitch
             entity = UnifiWlanSwitch(coordinator, rule, rule_type, config_entry_id)
+        elif rule_type == "qos_rules":
+            from .switch import UnifiQoSRuleSwitch
+            entity = UnifiQoSRuleSwitch(coordinator, rule, rule_type, config_entry_id)
         else:
             LOGGER.warning("Unknown rule type for entity creation: %s", rule_type)
             return False

--- a/custom_components/unifi_network_rules/const.py
+++ b/custom_components/unifi_network_rules/const.py
@@ -131,6 +131,9 @@ API_ENDPOINT_WLAN_DETAIL = "/proxy/network/api/s/{site}/rest/wlanconf/{wlan_id}"
 API_ENDPOINT_FIREWALL_ZONE_MATRIX = "/proxy/network/v2/api/site/{site}/firewall/zone-matrix"
 API_ENDPOINT_PORT_FORWARD = "/proxy/network/api/s/{site}/rest/portforward"
 API_ENDPOINT_PORT_FORWARD_DETAIL = "/proxy/network/api/s/{site}/rest/portforward/{forward_id}"
+API_ENDPOINT_QOS_RULES = "/proxy/network/v2/api/site/{site}/qos-rules"
+API_ENDPOINT_QOS_RULE_DETAIL = "/proxy/network/v2/api/site/{site}/qos-rules/{rule_id}"
+API_ENDPOINT_QOS_RULES_BATCH = "/proxy/network/v2/api/site/{site}/qos-rules/batch"
 
 # API Paths used for aiounifi API Requests
 API_PATH_FIREWALL_POLICIES = "/firewall-policies"
@@ -149,6 +152,9 @@ API_PATH_FIREWALL_ZONE_MATRIX = "/firewall/zone-matrix"
 API_PATH_WLANS = "/wlanconf"
 API_PATH_WLAN_DETAIL = "/wlanconf/{wlan_id}"
 API_PATH_SITE_FEATURE_MIGRATION = "/site-feature-migration"
+API_PATH_QOS_RULES = "/qos-rules"
+API_PATH_QOS_RULE_DETAIL = "/qos-rules/{rule_id}"
+API_PATH_QOS_RULES_BATCH = "/qos-rules/batch"
 
 # Detection endpoints
 API_ENDPOINT_SDN_STATUS = "/proxy/network/api/s/{site}/stat/sdn"

--- a/custom_components/unifi_network_rules/models/qos_rule.py
+++ b/custom_components/unifi_network_rules/models/qos_rule.py
@@ -1,0 +1,129 @@
+"""QoS rule model for UniFi Network Rules integration."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Union, Literal
+from dataclasses import dataclass
+
+@dataclass
+class QoSRuleDestination:
+    """Destination configuration for QoS rules."""
+    
+    app_ids: List[int] = None
+    matching_target: Literal["APP", "NETWORK", "PORT", "ANY"] = "ANY"
+    port_matching_type: Literal["ANY", "RANGE", "LIST"] = "ANY"
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> QoSRuleDestination:
+        """Create a QoSRuleDestination from a dictionary."""
+        return cls(
+            app_ids=data.get("app_ids", []),
+            matching_target=data.get("matching_target", "ANY"),
+            port_matching_type=data.get("port_matching_type", "ANY"),
+        )
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        result = {
+            "matching_target": self.matching_target,
+            "port_matching_type": self.port_matching_type,
+        }
+        if self.app_ids:
+            result["app_ids"] = self.app_ids
+        return result
+
+@dataclass
+class QoSRuleSource:
+    """Source configuration for QoS rules."""
+    
+    matching_target: Literal["ANY", "NETWORK", "GROUP"] = "ANY"
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> QoSRuleSource:
+        """Create a QoSRuleSource from a dictionary."""
+        return cls(
+            matching_target=data.get("matching_target", "ANY"),
+        )
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "matching_target": self.matching_target,
+        }
+
+@dataclass
+class QoSRuleSchedule:
+    """Schedule configuration for QoS rules."""
+    
+    mode: Literal["ALWAYS", "CUSTOM"] = "ALWAYS"
+    repeat_on_days: List[str] = None
+    time_all_day: bool = False
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> QoSRuleSchedule:
+        """Create a QoSRuleSchedule from a dictionary."""
+        return cls(
+            mode=data.get("mode", "ALWAYS"),
+            repeat_on_days=data.get("repeat_on_days", []),
+            time_all_day=data.get("time_all_day", False),
+        )
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "mode": self.mode,
+            "repeat_on_days": self.repeat_on_days or [],
+            "time_all_day": self.time_all_day,
+        }
+
+class QoSRule:
+    """Representation of a QoS routing rule."""
+    
+    def __init__(self, data: Dict[str, Any]) -> None:
+        """Initialize a QoS rule from raw data."""
+        self.raw = data
+        self._id = data.get("_id")
+        self.enabled = data.get("enabled", False)
+        self.name = data.get("name", "")
+        self.objective = data.get("objective", "PRIORITIZE")
+        self.index = data.get("index", 0)
+        self.download_burst = data.get("download_burst", "OFF")
+        self.upload_burst = data.get("upload_burst", "OFF")
+        
+        # Parse nested objects
+        self.destination = QoSRuleDestination.from_dict(data.get("destination", {}))
+        self.source = QoSRuleSource.from_dict(data.get("source", {}))
+        self.schedule = QoSRuleSchedule.from_dict(data.get("schedule", {}))
+    
+    @property
+    def id(self) -> str:
+        """Get the ID of the QoS rule."""
+        return self._id
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the QoS rule to a dictionary for API requests."""
+        result = {
+            "_id": self._id,
+            "enabled": self.enabled,
+            "name": self.name,
+            "objective": self.objective,
+            "index": self.index,
+            "download_burst": self.download_burst,
+            "upload_burst": self.upload_burst,
+            "destination": self.destination.to_dict(),
+            "source": self.source.to_dict(),
+            "schedule": self.schedule.to_dict(),
+        }
+        
+        return result
+
+class QoSRuleBatchToggleRequest:
+    """Model for batch QoS rule toggle requests."""
+    
+    def __init__(self, rule_ids: List[str], enabled: bool) -> None:
+        """Initialize the batch toggle request."""
+        self.rule_ids = rule_ids
+        self.enabled = enabled
+        
+    def to_dict(self) -> List[Dict[str, Any]]:
+        """Convert to API request payload."""
+        return [{"_id": rule_id, "enabled": self.enabled} for rule_id in self.rule_ids] 

--- a/custom_components/unifi_network_rules/services.yaml
+++ b/custom_components/unifi_network_rules/services.yaml
@@ -46,6 +46,7 @@ toggle_rule:
             - "port_forward"
             - "legacy_firewall"
             - "legacy_traffic"
+            - "qos_rule"
 
 backup_rules:
   name: Backup rules
@@ -112,15 +113,17 @@ restore_rules:
         Only restore specific types of rules (optional). Options:
         "policy" (firewall policies, legacy firewall rules, traffic rules),
         "route" (traffic routes only),
-        "port_forward" (port forwarding rules)
+        "port_forward" (port forwarding rules),
+        "qos_rule" (QoS quality of service rules)
       required: false
-      example: '["policy", "route"]'
+      example: '["policy", "route", "qos_rule"]'
       selector:
         select:
           options:
             - "policy"
             - "route"
             - "port_forward"
+            - "qos_rule"
           multiple: true
 
 bulk_update_rules:
@@ -167,6 +170,7 @@ delete_rule:
             - "port_forward"
             - "legacy_firewall"
             - "legacy_traffic"
+            - "qos_rule"
 
 apply_template:
   name: Apply template

--- a/custom_components/unifi_network_rules/services/rule_services.py
+++ b/custom_components/unifi_network_rules/services/rule_services.py
@@ -91,6 +91,9 @@ async def async_toggle_rule(hass: HomeAssistant, coordinators: Dict, call: Servi
         elif rule_type == "legacy_firewall_rules":
             rules = await api.get_legacy_firewall_rules()
             return next((r for r in rules if r.id == rule_id), None)
+        elif rule_type == "qos_rules":
+            rules = await api.get_qos_rules()
+            return next((r for r in rules if r.id == rule_id), None)
         elif rule_type == "wlans":
             wlans = await api.get_wlans()
             return next((w for w in wlans if w.id == rule_id), None)
@@ -108,6 +111,8 @@ async def async_toggle_rule(hass: HomeAssistant, coordinators: Dict, call: Servi
             return await api.queue_api_operation(api.toggle_traffic_route, rule_obj)
         elif rule_type == "legacy_firewall_rules":
             return await api.queue_api_operation(api.toggle_legacy_firewall_rule, rule_obj)
+        elif rule_type == "qos_rules":
+            return await api.queue_api_operation(api.toggle_qos_rule, rule_obj)
         elif rule_type == "wlans":
             return await api.queue_api_operation(api.toggle_wlan, rule_obj)
         return False
@@ -124,7 +129,7 @@ async def async_toggle_rule(hass: HomeAssistant, coordinators: Dict, call: Servi
                         break
             else:
                 # If rule_type is not specified, try all types
-                for type_name in ["firewall_policies", "traffic_rules", "port_forwards", "traffic_routes", "legacy_firewall_rules", "wlans"]:
+                for type_name in ["firewall_policies", "traffic_rules", "port_forwards", "traffic_routes", "legacy_firewall_rules", "qos_rules", "wlans"]:
                     try:
                         rule_obj = await get_rule_by_id(api, type_name, rule_id)
                         if rule_obj:
@@ -186,7 +191,7 @@ async def async_delete_rule(hass: HomeAssistant, coordinators: Dict, call: Servi
                     break
             else:
                 # Try all rule types
-                for type_name in ["firewall_policies", "traffic_rules", "port_forwards", "traffic_routes", "legacy_firewall_rules"]:
+                for type_name in ["firewall_policies", "traffic_rules", "port_forwards", "traffic_routes", "legacy_firewall_rules", "qos_rules"]:
                     try:
                         if await api.delete_rule(type_name, rule_id):
                             success = True
@@ -239,6 +244,8 @@ async def async_bulk_update_rules(hass: HomeAssistant, coordinators: Dict, call:
                 return await api.queue_toggle_traffic_route(rule_obj)
             elif rule_type == "legacy_firewall_rules":
                 return await api.queue_toggle_legacy_firewall_rule(rule_obj)
+            elif rule_type == "qos_rules":
+                return await api.queue_toggle_qos_rule(rule_obj)
             elif rule_type == "wlans":
                 return await api.queue_toggle_wlan(rule_obj)
         return True  # Already in desired state

--- a/custom_components/unifi_network_rules/udm/api.py
+++ b/custom_components/unifi_network_rules/udm/api.py
@@ -14,6 +14,7 @@ from .traffic import TrafficMixin
 from .port_forward import PortForwardMixin
 from .routes import RoutesMixin
 from .network import NetworkMixin
+from .qos import QoSMixin
 
 from ..const import LOGGER
 from ..queue import ApiOperationQueue
@@ -28,6 +29,7 @@ class UDMAPI(
     AuthenticationMixin,
     ApiHandlerMixin,
     CapabilitiesMixin,
+    QoSMixin,
     BaseAPI
 ):
     def __init__(self, *args, **kwargs):
@@ -181,6 +183,9 @@ class UDMAPI(
             # Get traffic routes
             await self.get_traffic_routes()
             
+            # Get QoS rules
+            await self.get_qos_rules()
+            
             # Get network-related info
             await self.get_firewall_zones()
             await self.get_wlans()
@@ -251,6 +256,11 @@ class UDMAPI(
                 rule = next((r for r in rules if str(r.get("_id")) == actual_id), None)
                 if rule:
                     return {"found": True, "enabled": rule.get("enabled", False), "data": rule}
+            elif rule_type == "qos_rules":
+                rules = await self.get_qos_rules()
+                rule = next((r for r in rules if str(r.id) == actual_id), None)
+                if rule:
+                    return {"found": True, "enabled": rule.enabled, "data": rule.raw}
                     
             # If we get here, rule was not found
             return {"found": False, "error": f"Rule {rule_id} not found"}

--- a/custom_components/unifi_network_rules/udm/api_base.py
+++ b/custom_components/unifi_network_rules/udm/api_base.py
@@ -121,4 +121,36 @@ class UDMAPI:
             return ApiRequestV2(method=method, path=path, data=data)
         else:
             from aiounifi.models.api import ApiRequest
-            return ApiRequest(method=method, path=path, data=data) 
+            return ApiRequest(method=method, path=path, data=data)
+
+    async def delete_rule(self, rule_type: str, rule_id: str) -> bool:
+        """Delete a rule based on its type.
+        
+        Args:
+            rule_type: The type of rule to delete
+            rule_id: The ID of the rule to delete
+            
+        Returns:
+            True if successful, False otherwise
+        """
+        LOGGER.debug("Deleting rule: type=%s, id=%s", rule_type, rule_id)
+        
+        try:
+            if rule_type == "firewall_policies":
+                return await self.remove_firewall_policy(rule_id)
+            elif rule_type == "traffic_rules":
+                return await self.remove_traffic_rule(rule_id)
+            elif rule_type == "port_forwards":
+                return await self.remove_port_forward(rule_id)
+            elif rule_type == "traffic_routes":
+                return await self.remove_traffic_route(rule_id)
+            elif rule_type == "legacy_firewall_rules":
+                return await self.remove_legacy_firewall_rule(rule_id)
+            elif rule_type == "qos_rules":
+                return await self.remove_qos_rule(rule_id)
+            else:
+                LOGGER.error("Unknown rule type: %s", rule_type)
+                return False
+        except Exception as err:
+            LOGGER.error("Error deleting rule: %s", str(err))
+            return False 

--- a/custom_components/unifi_network_rules/udm/qos.py
+++ b/custom_components/unifi_network_rules/udm/qos.py
@@ -1,0 +1,208 @@
+"""Module for UniFi QoS rule operations."""
+
+import logging
+import json
+from typing import Any, Dict, List, Optional
+
+from ..const import (
+    LOGGER, 
+    API_PATH_QOS_RULES,
+    API_PATH_QOS_RULE_DETAIL,
+    API_PATH_QOS_RULES_BATCH,
+)
+from ..models.qos_rule import QoSRule, QoSRuleBatchToggleRequest
+
+class QoSMixin:
+    """Mixin class for QoS rule operations."""
+
+    async def get_qos_rules(self) -> List[QoSRule]:
+        """Get all QoS rules.
+        
+        Returns:
+            List of QoSRule objects
+        """
+        try:         
+            # Using is_v2=True because this is a v2 API endpoint
+            request = self.create_api_request("GET", API_PATH_QOS_RULES, is_v2=True)
+            response = await self.controller.request(request)
+            
+            if response:
+                # Convert string response to json if needed
+                if isinstance(response, str):
+                    try:
+                        response = json.loads(response)
+                        LOGGER.debug("Converted string response to JSON object: %s", type(response))
+                    except json.JSONDecodeError as err:
+                        LOGGER.error("Failed to parse QoS rules response as JSON: %s", str(err))
+                        return []
+                
+                # Extract the data array from the response
+                data = None
+                if isinstance(response, dict) and "data" in response:
+                    data = response["data"]
+                    LOGGER.debug("Extracted data array from response envelope")
+                else:
+                    # If response doesn't have the expected structure, assume it's the data directly
+                    data = response
+                
+                # Now data should be a list
+                if not isinstance(data, list):
+                    LOGGER.error("Unable to extract rules list from response. Found %s", type(data))
+                    return []
+                
+                # Convert to typed QoSRule objects
+                result = []
+                for rule_data in data:
+                    # Create QoSRule objects
+                    rule = QoSRule(rule_data)
+                    result.append(rule)
+                LOGGER.debug("Converted %d QoS rules to typed objects", len(result))
+                return result
+            return []
+        except Exception as err:
+            LOGGER.error("Failed to get QoS rules: %s", str(err))
+            return []
+
+    async def add_qos_rule(self, rule_data: Dict[str, Any]) -> Optional[QoSRule]:
+        """Add a new QoS rule.
+        
+        Args:
+            rule_data: Dictionary containing the QoS rule configuration
+            
+        Returns:
+            QoSRule object if successful, None otherwise
+        """
+        LOGGER.debug("Adding QoS rule: %s", rule_data)
+        try:            
+            # Using is_v2=True because this is a v2 API endpoint
+            request = self.create_api_request("POST", API_PATH_QOS_RULES, data=rule_data, is_v2=True)
+            response = await self.controller.request(request)
+            
+            if response:
+                # Handle string response
+                if isinstance(response, str):
+                    try:
+                        response = json.loads(response)
+                    except json.JSONDecodeError as err:
+                        LOGGER.error("Failed to parse add QoS rule response as JSON: %s", str(err))
+                        return None
+                
+                # Extract data from response envelope if present
+                if isinstance(response, dict):
+                    if "data" in response:
+                        response = response["data"]
+                        LOGGER.debug("Extracted data from response envelope")
+                    elif "meta" in response and response["meta"].get("rc") != "ok":
+                        # Check for API error in meta
+                        LOGGER.error("API error adding QoS rule: %s", response["meta"].get("msg"))
+                        return None
+                
+                # Return a typed QoSRule object
+                return QoSRule(response)
+            return None
+        except Exception as err:
+            LOGGER.error("Failed to add QoS rule: %s", str(err))
+            return None
+
+    async def update_qos_rule(self, rule: QoSRule) -> bool:
+        """Update a QoS rule.
+        
+        Args:
+            rule: The QoSRule object to update
+            
+        Returns:
+            bool: True if the update was successful, False otherwise
+        """
+        rule_id = rule.id
+        LOGGER.debug("Updating QoS rule %s", rule_id)
+        try:
+            # Convert rule to dictionary for update
+            rule_dict = rule.to_dict()
+                
+            # Format API path with site name and rule ID
+            path = API_PATH_QOS_RULE_DETAIL.format(rule_id=rule_id)
+            
+            # Using is_v2=True because this is a v2 API endpoint
+            request = self.create_api_request("PUT", path, data=rule_dict, is_v2=True)
+            
+            # Execute the API call
+            await self.controller.request(request)
+            LOGGER.debug("QoS rule %s updated successfully", rule_id)
+            return True
+        except Exception as err:
+            LOGGER.error("Failed to update QoS rule: %s", str(err))
+            return False
+
+    async def toggle_qos_rule(self, rule: Any) -> bool:
+        """Toggle a QoS rule on/off.
+        
+        Args:
+            rule: QoSRule object or dictionary with rule data
+            
+        Returns:
+            bool: True if the toggle was successful, False otherwise
+        """
+        LOGGER.debug("Toggling QoS rule state")
+        try:
+            # Ensure we have a proper rule ID
+            rule_id = None
+            new_state = None
+            
+            if isinstance(rule, QoSRule):
+                rule_id = rule.id
+                new_state = not rule.enabled
+            elif isinstance(rule, dict) and "_id" in rule:
+                rule_id = rule["_id"]
+                new_state = not rule.get("enabled", False)
+            else:
+                LOGGER.error("Cannot determine rule ID from provided object: %s", type(rule))
+                return False
+            
+            LOGGER.debug("Toggling QoS rule %s to %s using batch API", rule_id, new_state)
+            
+            # Create batch toggle request
+            batch_request = QoSRuleBatchToggleRequest([rule_id], new_state)
+            
+            # Format API path
+            path = API_PATH_QOS_RULES_BATCH
+            
+            # Using is_v2=True because this is a v2 API endpoint
+            request = self.create_api_request(
+                "PUT", 
+                path, 
+                data=batch_request.to_dict(), 
+                is_v2=True
+            )
+            
+            # Execute the API call
+            await self.controller.request(request)
+            LOGGER.debug("QoS rule %s toggled successfully to %s", rule_id, new_state)
+            return True
+        except Exception as err:
+            LOGGER.error("Failed to toggle QoS rule: %s", str(err))
+            return False
+
+    async def remove_qos_rule(self, rule_id: str) -> bool:
+        """Remove a QoS rule.
+        
+        Args:
+            rule_id: ID of the QoS rule to remove
+            
+        Returns:
+            bool: True if the removal was successful, False otherwise
+        """
+        LOGGER.debug("Removing QoS rule: %s", rule_id)
+        try:
+            # Format API path with rule ID
+            path = API_PATH_QOS_RULE_DETAIL.format(rule_id=rule_id)
+            
+            # Using is_v2=True because this is a v2 API endpoint
+            request = self.create_api_request("DELETE", path, is_v2=True)
+            
+            # Execute the API call
+            await self.controller.request(request)
+            LOGGER.debug("QoS rule %s removed successfully", rule_id)
+            return True
+        except Exception as err:
+            LOGGER.error("Failed to remove QoS rule: %s", str(err))
+            return False 

--- a/custom_components/unifi_network_rules/websocket.py
+++ b/custom_components/unifi_network_rules/websocket.py
@@ -277,7 +277,8 @@ class UnifiRuleWebsocket:
         # Define keywords for rule-related messages
         rule_keywords = [
             "firewall", "rule", "policy", "network", "port", "route", "forward",
-            "nat", "security", "update", "change", "cfgversion", "provision"
+            "nat", "security", "update", "change", "cfgversion", "provision",
+            "qos", "quality", "service"  # Add QoS-related keywords
         ]
         
         # Extract message type for filtering


### PR DESCRIPTION
This pull request introduces support for QoS rules in the UniFi Network Rules integration. The changes include adding new API endpoints, updating the coordinator to handle QoS rules, and ensuring proper tracking and logging of these rules. Below are the most important changes:

#39 

### Support for QoS Rules:

* [`custom_components/unifi_network_rules/__init__.py`](diffhunk://#diff-0708519a6cc12eee3fb359614d48496df8f7414e7c07a4b53e31c1cce75019eeR372-R374): Added handling for `qos_rules` in the `async_create_entity` function.
* [`custom_components/unifi_network_rules/const.py`](diffhunk://#diff-c5c324c8f85b1103f6f9c7a4833ada673f430b792145ca28363d12a64cbb04caR134-R136): Added new API endpoints for QoS rules. [[1]](diffhunk://#diff-c5c324c8f85b1103f6f9c7a4833ada673f430b792145ca28363d12a64cbb04caR134-R136) [[2]](diffhunk://#diff-c5c324c8f85b1103f6f9c7a4833ada673f430b792145ca28363d12a64cbb04caR155-R157)
* [`custom_components/unifi_network_rules/coordinator.py`](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL25-R26): Imported `QoSRule` and updated the coordinator to handle QoS rules, including updating data, tracking, and logging. [[1]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL25-R26) [[2]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeR136) [[3]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeR145) [[4]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL217-R221) [[5]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL290-R299) [[6]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeR390-R403) [[7]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL435-R446) [[8]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeR517-R519) [[9]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeR528-R539) [[10]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL561-R581) [[11]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeR630-R633) [[12]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL640-R647) [[13]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL662-R672) [[14]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL737-R748) [[15]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL751-R762) [[16]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL789-R800) [[17]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeR829-R835) [[18]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeR869) [[19]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL862-R881) [[20]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL973-R1006)