### PR TITLE
RC fast-follow with QoS batch delete and some standard unit tests in prep for release

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -2,9 +2,9 @@ name: Test Suite
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 permissions:
   contents: read
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements_test.txt
+        pip install -r requirements.txt
 
     - name: Run tests
       run: |

--- a/custom_components/unifi_network_rules/const.py
+++ b/custom_components/unifi_network_rules/const.py
@@ -155,6 +155,7 @@ API_PATH_SITE_FEATURE_MIGRATION = "/site-feature-migration"
 API_PATH_QOS_RULES = "/qos-rules"
 API_PATH_QOS_RULE_DETAIL = "/qos-rules/{rule_id}"
 API_PATH_QOS_RULES_BATCH = "/qos-rules/batch"
+API_PATH_QOS_RULES_BATCH_DELETE = "/qos-rules/batch-delete"
 
 # Detection endpoints
 API_ENDPOINT_SDN_STATUS = "/proxy/network/api/s/{site}/stat/sdn"

--- a/custom_components/unifi_network_rules/udm/qos.py
+++ b/custom_components/unifi_network_rules/udm/qos.py
@@ -9,6 +9,7 @@ from ..const import (
     API_PATH_QOS_RULES,
     API_PATH_QOS_RULE_DETAIL,
     API_PATH_QOS_RULES_BATCH,
+    API_PATH_QOS_RULES_BATCH_DELETE,
 )
 from ..models.qos_rule import QoSRule, QoSRuleBatchToggleRequest
 
@@ -205,4 +206,38 @@ class QoSMixin:
             return True
         except Exception as err:
             LOGGER.error("Failed to remove QoS rule: %s", str(err))
+            return False
+
+    async def batch_delete_qos_rules(self, rule_ids: List[str]) -> bool:
+        """Delete multiple QoS rules at once.
+        
+        Args:
+            rule_ids: List of QoS rule IDs to delete
+            
+        Returns:
+            bool: True if the batch deletion was successful, False otherwise
+        """
+        if not rule_ids:
+            LOGGER.debug("No QoS rules to delete in batch operation")
+            return True
+            
+        LOGGER.debug("Batch deleting %d QoS rules: %s", len(rule_ids), rule_ids)
+        try:
+            # Path for batch delete
+            path = API_PATH_QOS_RULES_BATCH_DELETE
+            
+            # Using is_v2=True because this is a v2 API endpoint
+            request = self.create_api_request(
+                "POST", 
+                path, 
+                data=rule_ids, 
+                is_v2=True
+            )
+            
+            # Execute the API call
+            await self.controller.request(request)
+            LOGGER.debug("Successfully batch deleted %d QoS rules", len(rule_ids))
+            return True
+        except Exception as err:
+            LOGGER.error("Failed to batch delete QoS rules: %s", str(err))
             return False 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 homeassistant
 asyncio
+aiofiles
 aiohttp
+argparse
 aiounifi>=82.0.0
 pytest
 pytest-asyncio

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,34 @@
-# UniFi Network Rules Test Scripts
+# UniFi Network Rules Test Suite
 
-This directory contains test scripts to verify the functionality of the UniFi Network Rules integration.
+This directory contains test scripts and unit tests to verify the functionality of the UniFi Network Rules integration.
+
+## Unit Tests
+
+The integration includes a suite of unit tests to verify the functionality of various components:
+
+- `test_api.py`: Tests for the core API functionality
+- `test_firewall.py`: Tests for the firewall management API
+- `test_api_websocket.py`: Tests for WebSocket communication
+
+### Running the Unit Tests
+
+To run the unit tests:
+
+```bash
+pytest tests/
+```
+
+To run a specific test file:
+
+```bash
+pytest tests/test_api.py
+```
+
+To run with coverage report:
+
+```bash
+pytest tests/ --cov=custom_components.unifi_network_rules
+```
 
 ## WebSocket Test Script
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,171 @@
+"""Tests for the UniFi Network Rules API functionality."""
+import asyncio
+import pytest
+from unittest.mock import Mock, AsyncMock, patch, MagicMock
+
+from custom_components.unifi_network_rules.udm.api import UDMAPI
+from custom_components.unifi_network_rules.udm.api_base import UnifiNetworkRulesError, CannotConnect, InvalidAuth
+
+@pytest.fixture
+def api() -> UDMAPI:
+    """Return a UDMAPI instance with mocked controller."""
+    api = UDMAPI(
+        host="unifi.local",
+        username="admin",
+        password="password",
+        site="default",
+        verify_ssl=False,
+    )
+    api.controller = MagicMock()
+    api._initialized = True
+    return api
+
+@pytest.mark.asyncio
+async def test_init_creates_controller():
+    """Test init creates a controller."""
+    with patch(
+        "custom_components.unifi_network_rules.udm.authentication.AuthenticationMixin._create_controller_configuration"
+    ) as mock_create_config, patch(
+        "custom_components.unifi_network_rules.udm.authentication.AuthenticationMixin._create_controller"
+    ) as mock_create_controller, patch(
+        "custom_components.unifi_network_rules.udm.authentication.AuthenticationMixin._try_login",
+        return_value=True
+    ) as mock_login, patch(
+        "custom_components.unifi_network_rules.udm.api.UDMAPI.refresh_all"
+    ) as mock_refresh:
+        
+        mock_config = MagicMock()
+        mock_create_config.return_value = mock_config
+        mock_controller = MagicMock()
+        mock_create_controller.return_value = mock_controller
+        
+        api = UDMAPI(host="unifi.local", username="admin", password="password")
+        await api.async_init()
+        
+        mock_create_config.assert_called_once()
+        mock_create_controller.assert_called_once_with(mock_config)
+        mock_login.assert_called_once()
+        mock_refresh.assert_called_once()
+        assert api.controller == mock_controller
+        assert api.initialized
+
+@pytest.mark.asyncio
+async def test_login_failure_raises_invalid_auth():
+    """Test that login failure raises InvalidAuth."""
+    with patch(
+        "custom_components.unifi_network_rules.udm.authentication.AuthenticationMixin._create_controller_configuration"
+    ) as mock_create_config, patch(
+        "custom_components.unifi_network_rules.udm.authentication.AuthenticationMixin._create_controller"
+    ) as mock_create_controller, patch(
+        "custom_components.unifi_network_rules.udm.authentication.AuthenticationMixin._try_login",
+        side_effect=InvalidAuth("Authentication failed")
+    ) as mock_login:
+        
+        mock_config = MagicMock()
+        mock_create_config.return_value = mock_config
+        mock_controller = MagicMock()
+        mock_create_controller.return_value = mock_controller
+        
+        api = UDMAPI(host="unifi.local", username="admin", password="password")
+        with pytest.raises(InvalidAuth):
+            await api.async_init()
+
+@pytest.mark.asyncio
+async def test_cleanup(api):
+    """Test the cleanup method closes resources."""
+    # Mock API queue and controller
+    api.api_queue = AsyncMock()
+    api.api_queue.stop = AsyncMock()
+    api.controller = AsyncMock()
+    
+    await api.cleanup()
+    
+    api.api_queue.stop.assert_called_once()
+    # The controller itself isn't called, just used in the cleanup process
+    assert api.controller is None  # Controller should be set to None after cleanup
+
+@pytest.mark.asyncio
+async def test_queue_api_operation(api):
+    """Test that operations are properly queued."""
+    # Create the API queue mock
+    api.api_queue = AsyncMock()
+    api.api_queue.add_operation = AsyncMock()
+    
+    # Create a mock operation function
+    mock_operation = AsyncMock(return_value="success")
+    
+    # Queue the operation
+    future = await api.queue_api_operation(mock_operation, "arg1", kwarg1="value1")
+    
+    # Verify that add_operation was called
+    api.api_queue.add_operation.assert_called_once()
+    
+    # Complete the future to simulate the operation completing
+    # Extract the wrapper function that was passed to add_operation
+    wrapper_func = api.api_queue.add_operation.call_args[0][0]
+    
+    # Call the wrapper function to trigger the future completion
+    await wrapper_func()
+    
+    # Verify the mock was called with the arguments
+    mock_operation.assert_called_once_with("arg1", kwarg1="value1")
+    
+    # Check that the future was completed with the correct result
+    assert await future == "success"
+
+@pytest.mark.asyncio
+async def test_create_api_request(api):
+    """Test creating API requests."""
+    # Mock the internal _create_api_request method
+    api._create_api_request = Mock(return_value="api_request")
+    
+    # Test with standard parameters
+    result = api.create_api_request("GET", "/api/endpoint", data={"key": "value"})
+    
+    api._create_api_request.assert_called_once_with("GET", "/api/endpoint", {"key": "value"}, False)
+    assert result == "api_request"
+    
+    # Test with v2 API
+    api._create_api_request.reset_mock()
+    result = api.create_api_request("POST", "/api/v2/endpoint", data={"key": "value"}, is_v2=True)
+    
+    api._create_api_request.assert_called_once_with("POST", "/api/v2/endpoint", {"key": "value"}, True)
+    assert result == "api_request"
+
+@pytest.mark.asyncio
+async def test_sanitize_data_for_logging():
+    """Test that sensitive data is properly sanitized for logging."""
+    api = UDMAPI(host="unifi.local", username="admin", password="password")
+    
+    # Test with sensitive data
+    data = {
+        "username": "admin",
+        "password": "secret_password",
+        "token": "secret_token",
+        "key": "encryption_key",
+        "psk": "pre_shared_key",
+        "secret": "top_secret",
+        "auth": "auth_token",
+        "safe_field": "visible_data",
+    }
+    
+    sanitized = api._sanitize_data_for_logging(data)
+    
+    # Sensitive fields should be redacted
+    assert sanitized["password"] == "***REDACTED***"
+    assert sanitized["token"] == "***REDACTED***"
+    assert sanitized["key"] == "***REDACTED***"
+    assert sanitized["psk"] == "***REDACTED***"
+    assert sanitized["secret"] == "***REDACTED***"
+    assert sanitized["auth"] == "***REDACTED***"
+    
+    # Safe fields should be unchanged
+    assert sanitized["username"] == "admin"
+    assert sanitized["safe_field"] == "visible_data"
+    
+    # Original data should be unchanged
+    assert data["password"] == "secret_password"
+    
+    # Test with non-dict data
+    assert api._sanitize_data_for_logging("string_data") == "string_data"
+    assert api._sanitize_data_for_logging(None) is None

--- a/tests/test_api_websocket.py
+++ b/tests/test_api_websocket.py
@@ -1,0 +1,229 @@
+"""Tests for the UniFi Network Rules WebSocket functionality."""
+import asyncio
+import pytest
+import json
+from unittest.mock import Mock, AsyncMock, patch, MagicMock
+from aiohttp import WSMsgType, ClientWebSocketResponse
+
+from custom_components.unifi_network_rules.udm.websocket import CustomUnifiWebSocket, WebSocketMixin
+from custom_components.unifi_network_rules.udm.api import UDMAPI
+
+@pytest.fixture
+def ws_client():
+    """Return a CustomUnifiWebSocket instance."""
+    session = AsyncMock()
+    client = CustomUnifiWebSocket(
+        host="unifi.local",
+        site="default",
+        session=session,
+        headers={"Cookie": "auth=token", "X-CSRF-Token": "csrf_token"},
+        ssl=False
+    )
+    return client
+
+@pytest.fixture
+def api() -> UDMAPI:
+    """Return a UDMAPI instance with mocked controller."""
+    api = UDMAPI(
+        host="unifi.local",
+        username="admin",
+        password="password",
+        site="default",
+        verify_ssl=False,
+    )
+    api.controller = AsyncMock()
+    api._initialized = True
+    api._session = AsyncMock()
+    return api
+
+@pytest.mark.asyncio
+async def test_websocket_build_url(ws_client):
+    """Test building the WebSocket URL."""
+    url = ws_client._build_url()
+    assert url == "wss://unifi.local:443/proxy/network/wss/s/default/events"
+
+@pytest.mark.asyncio
+async def test_websocket_get_all_url_variants(ws_client):
+    """Test getting all WebSocket URL variants."""
+    variants = ws_client._get_all_url_variants()
+    # Check that we have the expected number of variants
+    assert len(variants) == 3
+    # Check that all variants contain the host and site
+    for variant in variants:
+        assert "unifi.local" in variant
+        assert "/default/" in variant or "namespace" in variant
+
+@pytest.mark.asyncio
+async def test_websocket_set_callbacks(ws_client):
+    """Test setting WebSocket callbacks."""
+    callback = Mock()
+    
+    # Test setting message callback
+    ws_client.set_message_callback(callback)
+    assert ws_client._message_callback == callback
+    
+    # Test setting compatibility callback
+    compatibility_callback = Mock()
+    ws_client.set_callback(compatibility_callback)
+    assert ws_client._callback == compatibility_callback
+
+@pytest.mark.asyncio
+async def test_websocket_connect_and_handle_messages(ws_client):
+    """Test WebSocket connection and message handling."""
+    # Create a mock WebSocket
+    mock_ws = AsyncMock()
+    
+    # Set up the mock session's ws_connect to return the mock WebSocket
+    ws_client._session.ws_connect = AsyncMock(return_value=mock_ws)
+    
+    # Set up a message handler that we can test directly
+    test_message = {
+        "meta": {"message": "firewall.update"},  # Use a rule-related message that will not be filtered
+        "data": {"key": "value"}
+    }
+    
+    # Set up a callback with a regular Mock (not AsyncMock)
+    # The code in CustomUnifiWebSocket doesn't await the callback
+    callback = Mock()
+    ws_client._message_callback = callback
+    
+    # Verify the URL is constructed correctly
+    url = ws_client._build_url()
+    assert "unifi.local" in url
+    assert "/proxy/network/wss/s/default/events" in url
+    
+    # Call the message handler directly
+    await ws_client._handle_message(json.dumps(test_message))
+    
+    # Verify the callback was called with the parsed message
+    callback.assert_called_once()
+    call_args = callback.call_args[0][0]
+    assert call_args["meta"]["message"] == "firewall.update"
+    assert call_args["data"]["key"] == "value"
+
+@pytest.mark.asyncio
+async def test_websocket_handle_message(ws_client):
+    """Test handling WebSocket messages."""
+    # Create a test message with rule-related content (should trigger callback)
+    rule_message = json.dumps({
+        "meta": {"message": "firewall.update"},
+        "data": {"rule_id": "123", "enabled": True}
+    })
+    
+    # Set up a callback that we'll manually check was called 
+    mock_callback = Mock()
+    # Use a normal Mock for simple assertion
+    ws_client._message_callback = mock_callback
+    
+    # Call the handle_message method directly
+    await ws_client._handle_message(rule_message)
+    
+    # Verify the callback was called with the parsed message
+    mock_callback.assert_called_once()
+    call_args = mock_callback.call_args[0][0]
+    assert call_args["meta"]["message"] == "firewall.update"
+    assert call_args["data"]["rule_id"] == "123"
+
+@pytest.mark.asyncio
+async def test_websocket_message_filtering(ws_client):
+    """Test WebSocket message filtering for non-rule updates."""
+    # Set up a callback
+    callback = AsyncMock()
+    ws_client.set_message_callback(callback)
+    
+    # Create a test message for device status (should be filtered)
+    device_status_message = json.dumps({
+        "meta": {"message": "device.status"},
+        "data": {"some": "data"}
+    })
+    
+    # Call the handle_message method
+    await ws_client._handle_message(device_status_message)
+    
+    # Verify the callback was NOT called since device.status should be filtered
+    callback.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_start_websocket_mixin(api):
+    """Test starting WebSocket with the WebSocketMixin."""
+    # Mock _get_auth_headers
+    api._get_auth_headers = AsyncMock(return_value={"Cookie": "auth=token", "X-CSRF-Token": "csrf_token"})
+    
+    # Mock the CustomUnifiWebSocket class
+    with patch("custom_components.unifi_network_rules.udm.websocket.CustomUnifiWebSocket") as mock_ws_class:
+        # Create a mock instance
+        mock_ws = AsyncMock()
+        mock_ws.connect = AsyncMock()
+        mock_ws_class.return_value = mock_ws
+        
+        # Call start_websocket
+        await api.start_websocket()
+        
+        # Verify that CustomUnifiWebSocket was created with the right params
+        mock_ws_class.assert_called_once()
+        call_args = mock_ws_class.call_args
+        assert call_args[1]["host"] == "unifi.local"
+        assert call_args[1]["site"] == "default"
+        assert call_args[1]["headers"] == {"Cookie": "auth=token", "X-CSRF-Token": "csrf_token"}
+        
+        # Verify that connect was called
+        mock_ws.connect.assert_called_once()
+        
+        # Verify that the custom WebSocket was stored
+        assert api._custom_websocket == mock_ws
+
+@pytest.mark.asyncio
+async def test_set_websocket_callback_mixin(api):
+    """Test setting WebSocket callback with the WebSocketMixin."""
+    # Create a callback function
+    callback = AsyncMock()
+    
+    # Create mock objects
+    api._custom_websocket = AsyncMock()
+    api._custom_websocket.set_message_callback = AsyncMock()
+    api.controller.ws_handler = None
+    
+    # Call set_websocket_callback
+    api.set_websocket_callback(callback)
+    
+    # Verify the callback was set correctly
+    assert api._ws_message_handler == callback
+    assert api.controller.ws_handler == callback
+    api._custom_websocket.set_message_callback.assert_called_once_with(callback)
+
+@pytest.mark.asyncio
+async def test_stop_websocket_mixin(api):
+    """Test stopping WebSocket with the WebSocketMixin."""
+    # Create mock objects
+    api._custom_websocket = AsyncMock()
+    api._custom_websocket.close = AsyncMock()
+    api.controller.stop_websocket = AsyncMock()
+    
+    # Call stop_websocket
+    await api.stop_websocket()
+    
+    # Verify both WebSockets were stopped
+    api.controller.stop_websocket.assert_called_once()
+    api._custom_websocket.close.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_get_auth_headers(api):
+    """Test getting authentication headers for WebSocket."""
+    # Create mock session with cookies
+    cookie_jar = MagicMock()
+    cookie1 = MagicMock()
+    cookie1.value = "value1"
+    cookies = {"cookie1": cookie1}
+    cookie_jar.filter_cookies.return_value = cookies
+    api._session.cookie_jar = cookie_jar
+    
+    # Set CSRF token
+    api._csrf_token = "csrf_token"
+    
+    # Call _get_auth_headers
+    headers = await api._get_auth_headers()
+    
+    # Verify the headers
+    assert "Cookie" in headers
+    assert "cookie1=value1" in headers["Cookie"]
+    assert headers["X-CSRF-Token"] == "csrf_token"

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -1,0 +1,286 @@
+"""Tests for the UniFi Network Rules Firewall API functionality."""
+import asyncio
+import pytest
+from unittest.mock import Mock, AsyncMock, patch, MagicMock
+
+from custom_components.unifi_network_rules.udm.api import UDMAPI
+from custom_components.unifi_network_rules.models.firewall_rule import FirewallRule
+
+@pytest.fixture
+def api() -> UDMAPI:
+    """Return a UDMAPI instance with mocked controller."""
+    api = UDMAPI(
+        host="unifi.local",
+        username="admin",
+        password="password",
+        site="default",
+        verify_ssl=False,
+    )
+    api.controller = AsyncMock()
+    api._initialized = True
+    return api
+
+@pytest.fixture
+def firewall_policy_data():
+    """Return example firewall policy data."""
+    return {
+        "id": "123456789",
+        "_id": "123456789",
+        "name": "Test Policy",
+        "description": "Test firewall policy",
+        "enabled": True,
+        "action": "accept",
+        "protocol": "all",
+        "ruleset": "WAN_IN",
+        "dst_address": "10.0.0.0/8",
+        "src_address": "any",
+        "position": 2000,
+        "predefined": False
+    }
+
+@pytest.fixture
+def firewall_rule_data():
+    """Return example legacy firewall rule data."""
+    return {
+        "id": "987654321",
+        "_id": "987654321",
+        "name": "Legacy Rule",
+        "description": "Test legacy rule",
+        "enabled": True,
+        "action": "accept",
+        "protocol": "tcp",
+        "protocol_match_excepted": False,
+        "dst_address": "192.168.1.0/24",
+        "src_address": "any",
+        "rule_index": 2000,
+        "src_firewall_group_ids": [],
+        "dst_firewall_group_ids": []
+    }
+
+@pytest.mark.asyncio
+async def test_get_firewall_policies(api, firewall_policy_data):
+    """Test retrieving firewall policies."""
+    # Mock the controller request method
+    api.controller.request = AsyncMock(return_value={"data": [firewall_policy_data]})
+    
+    # Call the method
+    policies = await api.get_firewall_policies()
+    
+    # Verify controller request was called
+    assert api.controller.request.called
+    
+    # Verify the policies are returned correctly
+    assert len(policies) == 1
+    policy = policies[0]
+    assert policy.id == "123456789"
+    assert policy.name == "Test Policy"
+    assert policy.enabled is True
+
+@pytest.mark.asyncio
+async def test_get_firewall_policies_excludes_predefined(api):
+    """Test that predefined policies are excluded by default."""
+    # Sample data with both predefined and custom policies
+    policies_data = [
+        {
+            "_id": "123",
+            "name": "Custom Policy",
+            "predefined": False,
+            "enabled": True
+        },
+        {
+            "_id": "456",
+            "name": "Predefined Policy",
+            "predefined": True,
+            "enabled": True
+        }
+    ]
+    
+    # Mock the controller request method
+    api.controller.request = AsyncMock(return_value={"data": policies_data})
+    
+    # Call the method with default parameters (exclude predefined)
+    policies = await api.get_firewall_policies()
+    
+    # Verify only custom policies are returned
+    assert len(policies) == 1
+    assert policies[0].name == "Custom Policy"
+    
+    # Now include predefined policies
+    policies = await api.get_firewall_policies(include_predefined=True)
+    
+    # Verify both types are returned
+    assert len(policies) == 2
+    policy_names = [p.name for p in policies]
+    assert "Custom Policy" in policy_names
+    assert "Predefined Policy" in policy_names
+
+@pytest.mark.asyncio
+async def test_add_firewall_policy(api, firewall_policy_data):
+    """Test adding a firewall policy."""
+    # Mock the controller request method
+    api.controller.request = AsyncMock(return_value={"data": [firewall_policy_data]})
+    
+    # Mock create_api_request
+    api.create_api_request = Mock(return_value="mock_request")
+    
+    # Call the method
+    policy = await api.add_firewall_policy(firewall_policy_data)
+    
+    # Verify create_api_request was called correctly
+    api.create_api_request.assert_called_once()
+    args = api.create_api_request.call_args[0]
+    assert args[0] == "POST"  # Method is first arg
+    assert "is_v2" in api.create_api_request.call_args[1]
+    assert api.create_api_request.call_args[1]["is_v2"] is True
+    
+    # Verify controller request was called
+    api.controller.request.assert_called_once_with("mock_request")
+    
+    # Verify the policy is returned correctly
+    assert policy.id == "123456789"
+    assert policy.name == "Test Policy"
+    assert policy.enabled is True
+
+@pytest.mark.asyncio
+async def test_update_firewall_policy(api, firewall_policy_data):
+    """Test updating a firewall policy."""
+    # Create a firewall policy object
+    from aiounifi.models.firewall_policy import FirewallPolicy
+    policy = FirewallPolicy(firewall_policy_data)
+    
+    # Mock the controller request method
+    api.controller.request = AsyncMock(return_value={"data": [firewall_policy_data]})
+    
+    # Call the method
+    result = await api.update_firewall_policy(policy)
+    
+    # Verify controller request was called
+    assert api.controller.request.called
+    
+    # Verify the result is True
+    assert result is True
+
+@pytest.mark.asyncio
+async def test_remove_firewall_policy(api):
+    """Test removing a firewall policy."""
+    # Mock the create_api_request method
+    api.create_api_request = Mock(return_value="mock_request")
+    
+    # Mock the controller request method
+    api.controller.request = AsyncMock(return_value={"meta": {"rc": "ok"}})
+    
+    # Call the method
+    result = await api.remove_firewall_policy("123456789")
+    
+    # Verify create_api_request was called correctly
+    api.create_api_request.assert_called_once()
+    args = api.create_api_request.call_args[0]
+    assert args[0] == "POST"  # Method is first arg
+    assert "is_v2" in api.create_api_request.call_args[1]
+    assert api.create_api_request.call_args[1]["is_v2"] is True
+    
+    # Verify controller request was called
+    api.controller.request.assert_called_once_with("mock_request")
+    
+    # Verify the result is True
+    assert result is True
+
+@pytest.mark.asyncio
+async def test_toggle_firewall_policy(api, firewall_policy_data):
+    """Test toggling a firewall policy."""
+    # Create a firewall policy object
+    from aiounifi.models.firewall_policy import FirewallPolicy
+    policy = FirewallPolicy(firewall_policy_data)
+    original_state = policy.enabled
+    
+    # Mock the controller request method
+    api.controller.request = AsyncMock(return_value={"meta": {"rc": "ok"}})
+    
+    # Call the method
+    result = await api.toggle_firewall_policy(policy)
+    
+    # Verify controller request was called
+    assert api.controller.request.called
+    
+    # Get the request that was passed to controller.request
+    request = api.controller.request.call_args[0][0]
+    
+    # Verify the request has the toggled enabled value
+    assert hasattr(request, "data")
+    assert request.data["enabled"] is not original_state
+    
+    # Verify the result is True
+    assert result is True
+
+@pytest.mark.asyncio
+async def test_queue_toggle_firewall_policy(api, firewall_policy_data):
+    """Test queueing a toggle operation for a firewall policy."""
+    # Create a firewall policy object
+    from aiounifi.models.firewall_policy import FirewallPolicy
+    policy = FirewallPolicy(firewall_policy_data)
+    
+    # Mock the queue_api_operation method
+    future = asyncio.Future()
+    future.set_result(True)
+    api.queue_api_operation = AsyncMock(return_value=future)
+    
+    # Call the method
+    result = await api.queue_toggle_firewall_policy(policy)
+    
+    # Verify queue_api_operation was called with toggle_firewall_policy
+    api.queue_api_operation.assert_called_once()
+    assert api.queue_api_operation.call_args[0][0] == api.toggle_firewall_policy
+    assert api.queue_api_operation.call_args[0][1] == policy
+    
+    # Verify the result is True
+    assert result is True
+
+@pytest.mark.asyncio
+async def test_get_legacy_firewall_rules(api, firewall_rule_data):
+    """Test retrieving legacy firewall rules."""
+    # Mock the controller request method
+    api.controller.request = AsyncMock(return_value={"data": [firewall_rule_data]})
+    
+    # Mock the create_api_request method
+    api.create_api_request = Mock(return_value="mock_request")
+    
+    # Call the method
+    rules = await api.get_legacy_firewall_rules()
+    
+    # Verify create_api_request was called correctly
+    api.create_api_request.assert_called_once()
+    
+    # Verify controller request was called
+    api.controller.request.assert_called_once_with("mock_request")
+    
+    # Verify the rules are returned correctly
+    assert len(rules) == 1
+    rule = rules[0]
+    assert isinstance(rule, FirewallRule)
+    assert rule.id == "987654321"
+    assert rule.name == "Legacy Rule"
+    assert rule.enabled is True
+
+@pytest.mark.asyncio
+async def test_add_legacy_firewall_rule(api, firewall_rule_data):
+    """Test adding a legacy firewall rule."""
+    # Mock the controller request method
+    api.controller.request = AsyncMock(return_value=firewall_rule_data)
+    
+    # Mock create_api_request
+    api.create_api_request = Mock(return_value="mock_request")
+    
+    # Call the method
+    rule = await api.add_legacy_firewall_rule(firewall_rule_data)
+    
+    # Verify create_api_request was called correctly
+    api.create_api_request.assert_called_once()
+    
+    # Verify controller request was called
+    api.controller.request.assert_called_once_with("mock_request")
+    
+    # Verify the rule is returned correctly
+    assert isinstance(rule, FirewallRule)
+    assert rule.id == "987654321"
+    assert rule.name == "Legacy Rule"
+    assert rule.enabled is True


### PR DESCRIPTION
This pull request introduces several significant changes to the UniFi Network Rules integration, including the addition of a new batch delete feature for QoS rules, updates to the test suite, and the inclusion of unit tests for API and WebSocket functionalities.

### New Feature:
* Added a new API path `API_PATH_QOS_RULES_BATCH_DELETE` for batch deleting QoS rules (`custom_components/unifi_network_rules/const.py`).
* Implemented the `batch_delete_qos_rules` method to handle the batch deletion of QoS rules (`custom_components/unifi_network_rules/udm/qos.py`).

### Test Suite Enhancements:
* Updated the `tests/README.md` to include instructions for running unit tests and a description of the test suite.

### Unit Tests:
* Added comprehensive unit tests for the UniFi Network Rules API functionality, including tests for initialization, login failure, cleanup, API request creation, and data sanitization (`tests/test_api.py`).
* Added unit tests for the WebSocket functionality, including tests for URL construction, message handling, and WebSocket operations (`tests/test_api_websocket.py`).