### PR TITLE
Updated default switch style to render as an toggle / outlet in HA

### DIFF
--- a/custom_components/unifi_network_rules/manifest.json
+++ b/custom_components/unifi_network_rules/manifest.json
@@ -15,5 +15,5 @@
         "aiounifi>=82.0.0",
         "orjson>=3.8.0"
     ],
-    "version": "2.2.0"
+    "version": "2.2.1-beta.1"
 }

--- a/custom_components/unifi_network_rules/switch.py
+++ b/custom_components/unifi_network_rules/switch.py
@@ -340,6 +340,12 @@ class UnifiRuleSwitch(CoordinatorEntity[UnifiRuleUpdateCoordinator], SwitchEntit
         # Set has_entity_name to False to ensure the entity name is shown in UI
         self._attr_has_entity_name = False
         
+        # Set default icon for all rule switches (can be overridden by subclasses)
+        self._attr_icon = "mdi:toggle-switch"
+        
+        # Set device class to outlet to force toggle/slider rendering instead of icon button
+        self._attr_device_class = "outlet"
+        
         # Set device info
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.api.host)},
@@ -1094,7 +1100,8 @@ class UnifiPortForwardSwitch(UnifiRuleSwitch):
     ) -> None:
         """Initialize port forward switch."""
         super().__init__(coordinator, rule_data, rule_type, entry_id)
-        # Add any port-forward specific functionality here
+        # Set icon for port forward rules
+        self._attr_icon = "mdi:network-pos"
 
 class UnifiTrafficRouteSwitch(UnifiRuleSwitch):
     """Switch to enable/disable a UniFi traffic route rule."""
@@ -1108,7 +1115,8 @@ class UnifiTrafficRouteSwitch(UnifiRuleSwitch):
     ) -> None:
         """Initialize traffic route switch."""
         super().__init__(coordinator, rule_data, rule_type, entry_id)
-        # Add any traffic-route specific functionality here
+        # Set icon for traffic route rules
+        self._attr_icon = "mdi:directions-fork"
 
 class UnifiFirewallPolicySwitch(UnifiRuleSwitch):
     """Switch to enable/disable a UniFi firewall policy."""
@@ -1122,7 +1130,8 @@ class UnifiFirewallPolicySwitch(UnifiRuleSwitch):
     ) -> None:
         """Initialize firewall policy switch."""
         super().__init__(coordinator, rule_data, rule_type, entry_id)
-        # Add any firewall-policy specific functionality here
+        # Set icon for firewall policy rules
+        self._attr_icon = "mdi:shield-check"
 
 class UnifiTrafficRuleSwitch(UnifiRuleSwitch):
     """Switch to enable/disable a UniFi traffic rule."""
@@ -1136,7 +1145,8 @@ class UnifiTrafficRuleSwitch(UnifiRuleSwitch):
     ) -> None:
         """Initialize traffic rule switch."""
         super().__init__(coordinator, rule_data, rule_type, entry_id)
-        # Add any traffic-rule specific functionality here
+        # Set icon for traffic rules
+        self._attr_icon = "mdi:traffic-light"
 
 class UnifiLegacyFirewallRuleSwitch(UnifiRuleSwitch):
     """Switch to enable/disable a UniFi legacy firewall rule."""
@@ -1150,7 +1160,8 @@ class UnifiLegacyFirewallRuleSwitch(UnifiRuleSwitch):
     ) -> None:
         """Initialize legacy firewall rule switch."""
         super().__init__(coordinator, rule_data, rule_type, entry_id)
-        # Add any legacy-firewall specific functionality here
+        # Set icon for legacy firewall rules
+        self._attr_icon = "mdi:shield-outline"
 
 class UnifiWlanSwitch(UnifiRuleSwitch):
     """Switch to enable/disable a UniFi wireless network."""
@@ -1164,7 +1175,8 @@ class UnifiWlanSwitch(UnifiRuleSwitch):
     ) -> None:
         """Initialize WLAN switch."""
         super().__init__(coordinator, rule_data, rule_type, entry_id)
-        # Add any WLAN-specific functionality here
+        # Set icon for WLAN switches
+        self._attr_icon = "mdi:wifi"
 
 class UnifiTrafficRouteKillSwitch(UnifiRuleSwitch):
     """Switch to enable/disable kill switch for a UniFi traffic route rule."""
@@ -1224,6 +1236,9 @@ class UnifiTrafficRouteKillSwitch(UnifiRuleSwitch):
         # 5. Linking Information (Parent ID needed for lookups)
         self._linked_parent_id = original_rule_id # Store parent's unique_id
         self._linked_child_ids = set() # Kill switches have no children
+
+        # Set icon for kill switch
+        self._attr_icon = "mdi:shield-off"
 
         # Global tracking is now handled in base async_added_to_hass
 
@@ -1456,7 +1471,8 @@ class UnifiQoSRuleSwitch(UnifiRuleSwitch):
         LOGGER.info("Initializing QoS rule switch with data: %s (type: %s)", 
                   getattr(rule_data, "id", "unknown"), type(rule_data).__name__)
         super().__init__(coordinator, rule_data, rule_type, entry_id)
-        # Add any QoS-rule specific functionality here
+        # Set icon for QoS rules
+        self._attr_icon = "mdi:speedometer"
 
 class UnifiVPNClientSwitch(UnifiRuleSwitch):
     """Switch to enable/disable a UniFi VPN client."""


### PR DESCRIPTION
This maintains consistency with other unifi integrations. Also added more contextual default icons to each switch type to reduce the reliance on custom button templates.

fixes #59 

This pull request introduces a version update and enhances the `switch.py` file by standardizing and setting specific icons for various UniFi rule switches to improve UI consistency and user experience. Below are the most important changes:

### Version Update:
* Updated the version in `manifest.json` from `2.2.0` to `2.2.1-beta.1`, indicating a beta release with new features or improvements.

### UI Enhancements for Switches:
* **Default Switch Settings:**
  * Added a default icon (`mdi:toggle-switch`) and set the device class to `outlet` for all rule switches, ensuring consistent rendering in the UI.

* **Specific Icons for Rule Switches:**
  * Set unique icons for different types of switches to visually distinguish them in the UI:
    - Port Forward: `mdi:network-pos`
    - Traffic Route: `mdi:directions-fork`
    - Firewall Policy: `mdi:shield-check`
    - Traffic Rule: `mdi:traffic-light`
    - Legacy Firewall: `mdi:shield-outline`
    - WLAN: `mdi:wifi`
    - Kill Switch: `mdi:shield-off`
    - QoS Rule: `mdi:speedometer`