### PR TITLE
Modify default assumed state of every switch to True

### DIFF
--- a/custom_components/unifi_network_rules/manifest.json
+++ b/custom_components/unifi_network_rules/manifest.json
@@ -15,5 +15,5 @@
         "aiounifi>=82.0.0",
         "orjson>=3.8.0"
     ],
-    "version": "2.2.1-beta.1"
+    "version": "2.2.1-beta.2"
 }

--- a/custom_components/unifi_network_rules/switch.py
+++ b/custom_components/unifi_network_rules/switch.py
@@ -9,7 +9,7 @@ import contextlib
 import re
 import copy
 
-from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription, PLATFORM_SCHEMA
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription, SwitchDeviceClass, PLATFORM_SCHEMA
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
@@ -343,9 +343,6 @@ class UnifiRuleSwitch(CoordinatorEntity[UnifiRuleUpdateCoordinator], SwitchEntit
         # Set default icon for all rule switches (can be overridden by subclasses)
         self._attr_icon = "mdi:toggle-switch"
         
-        # Set device class to outlet to force toggle/slider rendering instead of icon button
-        self._attr_device_class = "outlet"
-        
         # Set device info
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.api.host)},
@@ -602,8 +599,8 @@ class UnifiRuleSwitch(CoordinatorEntity[UnifiRuleUpdateCoordinator], SwitchEntit
 
     @property
     def assumed_state(self) -> bool:
-        """Return True as we're implementing optimistic state."""
-        return True
+        """Return False to get toggle slider UI instead of icon buttons."""
+        return False
 
     def _get_current_rule(self) -> Any | None:
         """Get current rule data from coordinator."""


### PR DESCRIPTION
This setting will allow the switch to render as a toggle by default instead of two separate on/off buttons

#59 

This pull request includes updates to the `unifi_network_rules` custom component, focusing on improving the user interface for switches and updating dependencies. The most important changes include modifying the switch behavior to enable a toggle slider UI, removing the hardcoded device class, and updating the version in the manifest file.

### Improvements to switch behavior and UI:

* [`custom_components/unifi_network_rules/switch.py`](diffhunk://#diff-3dc98f2106760a661479e39206538a7db72ea1cb31513a454e4195b94139e97cL346-L348): Removed the hardcoded `device_class` attribute for switches, allowing the UI to render toggle sliders naturally without forcing the "outlet" device class.
* [`custom_components/unifi_network_rules/switch.py`](diffhunk://#diff-3dc98f2106760a661479e39206538a7db72ea1cb31513a454e4195b94139e97cL605-R603): Updated the `assumed_state` property to return `False`, enabling the toggle slider UI instead of icon buttons.
* [`custom_components/unifi_network_rules/switch.py`](diffhunk://#diff-3dc98f2106760a661479e39206538a7db72ea1cb31513a454e4195b94139e97cL12-R12): Added the `SwitchDeviceClass` import, preparing for potential future enhancements to switch device classifications.

### Dependency and version updates:

* [`custom_components/unifi_network_rules/manifest.json`](diffhunk://#diff-3ff6e42bb78c06c3571279a5544e949b19a7c4a2613e73e8914134a7fac01f43L18-R18): Updated the component version from `2.2.1-beta.1` to `2.2.1-beta.2` to reflect the latest changes.