### PR TITLE
Update GitHub Actions workflows to include `pull_request_target` to support workflows on Fork PR's

### DIFF
--- a/.github/workflows/hacs-integration.yml
+++ b/.github/workflows/hacs-integration.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   push:
   pull_request:
+  pull_request_target:
 
 permissions:
   contents: read

--- a/.github/workflows/hass-validation.yml
+++ b/.github/workflows/hass-validation.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   push:
   pull_request:
+  pull_request_target:
 
 permissions:
   contents: read

--- a/custom_components/unifi_network_rules/manifest.json
+++ b/custom_components/unifi_network_rules/manifest.json
@@ -15,5 +15,5 @@
         "aiounifi>=82.0.0",
         "orjson>=3.8.0"
     ],
-    "version": "3.0.0"
+    "version": "3.0.1"
 }


### PR DESCRIPTION
This pull request introduces updates to GitHub Actions workflows and a minor version bump in the `unifi_network_rules` integration. The most important changes include adding `pull_request_target` triggers to workflows and updating the version in the `manifest.json` file.

### Workflow updates:
* [`.github/workflows/hacs-integration.yml`](diffhunk://#diff-b7d6857e0f0135259907dabdaed87669b4d1b353fa56af9c7bbeb1513a7c32cfR7): Added `pull_request_target` as a trigger to the workflow to enable execution for pull requests from forks.
* [`.github/workflows/hass-validation.yml`](diffhunk://#diff-da6bd7f39767715c8788fe3e7f92a091410e39c6e87c8a46178a334c484f1f7cR7): Added `pull_request_target` as a trigger to the workflow to ensure validation runs for pull requests from forks.

### Integration version update:
* [`custom_components/unifi_network_rules/manifest.json`](diffhunk://#diff-3ff6e42bb78c06c3571279a5544e949b19a7c4a2613e73e8914134a7fac01f43L18-R18): Updated the version from `3.0.0` to `3.0.1` to reflect a minor update.