### PR TITLE
Updated network API to send only essential fields, preventing InvalidPayload errors on older UniFi Network versions

### DIFF
--- a/custom_components/unifi_network_rules/manifest.json
+++ b/custom_components/unifi_network_rules/manifest.json
@@ -15,5 +15,5 @@
         "aiounifi>=82.0.0",
         "orjson>=3.8.0"
     ],
-    "version": "3.1.0"
+    "version": "3.1.1"
 }

--- a/custom_components/unifi_network_rules/udm/network.py
+++ b/custom_components/unifi_network_rules/udm/network.py
@@ -144,8 +144,8 @@ class NetworkMixin:
             like brightness and color control, a Light entity would be more appropriate.
             
         Implementation:
-            Uses the pattern of getting full device payload, modifying only the LED field,
-            and PUTting the entire payload back to the device-specific endpoint.
+            Sends only essential device fields to avoid InvalidPayload errors on older
+            UniFi Network versions that reject read-only fields in update requests.
         """
         try:
             device_id = device.id
@@ -155,11 +155,19 @@ class NetworkMixin:
             device_raw = getattr(device, 'raw', {}) if hasattr(device, 'raw') else {}
             device_mac = device_raw.get('mac', device_raw.get('serial', 'unknown'))
             
-            # Get the current device configuration (full payload)
-            device_payload = device.raw.copy() if hasattr(device, 'raw') and device.raw else {}
+            # Create minimal payload with only essential fields to avoid InvalidPayload errors
+            # Many fields in the full device payload are read-only and cause API errors
+            device_payload = {
+                '_id': device_id,
+                'led_override': status
+            }
             
-            # Modify only the LED override field
-            device_payload['led_override'] = status
+            # Include optional LED fields if they exist in the original data
+            # to maintain any existing LED configuration
+            if 'led_override_color' in device_raw:
+                device_payload['led_override_color'] = device_raw['led_override_color']
+            if 'led_override_color_brightness' in device_raw:
+                device_payload['led_override_color_brightness'] = device_raw['led_override_color_brightness']
             
             # Use the legacy API endpoint for device updates (not v2)
             # Path format: /rest/device/{device_id}


### PR DESCRIPTION
This pull request includes a version update and improvements to the `set_device_led` method to handle API compatibility issues with older UniFi Network versions. The changes focus on reducing payload size in device update requests to prevent errors caused by read-only fields.

fixes #80 

### Version Update:
* [`custom_components/unifi_network_rules/manifest.json`](diffhunk://#diff-3ff6e42bb78c06c3571279a5544e949b19a7c4a2613e73e8914134a7fac01f43L18-R18): Updated the version from `3.1.0` to `3.1.1` to reflect the new changes.

### API Compatibility Improvements:
* [`custom_components/unifi_network_rules/udm/network.py`](diffhunk://#diff-50acc0a424fed301a5f736e67e8b8ae060bf3121c6316d8e30f8cba91568eb97L147-R148): Modified the `set_device_led` method to send a minimal payload with only essential fields (`_id` and `led_override`) instead of the full device payload. This avoids `InvalidPayload` errors on older UniFi Network versions that reject read-only fields. [[1]](diffhunk://#diff-50acc0a424fed301a5f736e67e8b8ae060bf3121c6316d8e30f8cba91568eb97L147-R148) [[2]](diffhunk://#diff-50acc0a424fed301a5f736e67e8b8ae060bf3121c6316d8e30f8cba91568eb97L158-R170)
* Added logic to include optional LED-related fields (`led_override_color` and `led_override_color_brightness`) if they exist in the original data, ensuring existing LED configurations are preserved.