### PR TITLE
Feat/port profile switch entities

### DIFF
--- a/custom_components/unifi_network_rules/models/network.py
+++ b/custom_components/unifi_network_rules/models/network.py
@@ -1,0 +1,32 @@
+"""Typed model for UniFi network (networkconf) entries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class NetworkConf:
+    raw: Dict[str, Any]
+
+    @property
+    def id(self) -> str:
+        return str(self.raw.get("_id") or self.raw.get("id") or "")
+
+    @property
+    def name(self) -> str:
+        return str(self.raw.get("name") or self.raw.get("attr_hidden_id") or f"Network {self.id}")
+
+    @property
+    def purpose(self) -> str:
+        return str(self.raw.get("purpose") or "")
+
+    @property
+    def enabled(self) -> bool:
+        # Some networkconfs may not have enabled; treat presence of ip_subnet or WAN purpose as enabled
+        if "enabled" in self.raw:
+            return bool(self.raw.get("enabled"))
+        return True
+
+

--- a/custom_components/unifi_network_rules/models/port_profile.py
+++ b/custom_components/unifi_network_rules/models/port_profile.py
@@ -1,0 +1,42 @@
+"""Typed model for UniFi Ethernet Port Profile used by UNR.
+
+Keeps raw dict from controller but exposes typed accessors for id, name,
+and computed enabled state that we use for switch entities.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class PortProfile:
+    """Represents a UniFi Port Profile with helper accessors.
+
+    Enabled is a computed concept for UNR: a profile is considered "enabled"
+    when it has a native network assigned and management VLAN is not blocked.
+    """
+
+    raw: Dict[str, Any]
+
+    @property
+    def id(self) -> str:
+        return str(self.raw.get("_id") or self.raw.get("id") or "")
+
+    @property
+    def name(self) -> str:
+        return str(self.raw.get("name") or self.raw.get("description") or f"Port Profile {self.id}")
+
+    @property
+    def enabled(self) -> bool:
+        native = self.raw.get("native_networkconf_id")
+        tagged_mgmt = self.raw.get("tagged_vlan_mgmt")
+        # Treat as enabled if a native network is configured and mgmt VLANs are not blocked
+        return bool(native) and tagged_mgmt not in {"block_all", "block-custom"}
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a shallow copy of the raw dict suitable for updates."""
+        return dict(self.raw)
+
+

--- a/custom_components/unifi_network_rules/udm/network.py
+++ b/custom_components/unifi_network_rules/udm/network.py
@@ -1,7 +1,8 @@
 """Module for UniFi network operations."""
 
-import logging
-from typing import Any, Dict, List, Optional, Tuple
+from __future__ import annotations
+
+from typing import Any, List
 
 # Import directly from specific modules
 from aiounifi.models.firewall_zone import FirewallZoneListRequest, FirewallZone
@@ -13,11 +14,12 @@ from aiounifi.models.wlan import (
 
 from ..const import (
     LOGGER,
-    API_PATH_WLAN_DETAIL
+    API_PATH_WLAN_DETAIL,
+    API_PATH_NETWORK_CONF,
 )
 
-from aiounifi.models.device import Device, DeviceSetLedStatus
-from aiounifi.models.api import ApiRequest
+from aiounifi.models.device import Device
+from ..models.network import NetworkConf
 
 class NetworkMixin:
     """Mixin class for network operations."""
@@ -238,4 +240,18 @@ class NetworkMixin:
             return []
         except Exception as err:
             LOGGER.error("Failed to get device LED states: %s", str(err))
+            return []
+
+    async def get_networks(self) -> List[NetworkConf]:
+        """Get all network configurations (networkconf)."""
+        try:
+            request = self.create_api_request("GET", API_PATH_NETWORK_CONF)
+            data = await self.controller.request(request)
+            items: List[NetworkConf] = []
+            if data and isinstance(data, dict) and "data" in data:
+                for n in data["data"]:
+                    items.append(NetworkConf(n))
+            return items
+        except Exception as err:
+            LOGGER.error("Failed to get networks: %s", str(err))
             return []


### PR DESCRIPTION
New feature adding switch support for all networks, including WAN, LAN, and new UniFi WAN magic, along with Port Profile switches. Based on the requested features #87 and #99 

This pull request adds support for managing UniFi networks and port profiles in the coordinator, improves VPN client/server derivation logic, and enhances helper functions to correctly handle these new types. The update refactors how VPN entities are determined, ensuring more accurate and robust handling by deriving them from network data. It also introduces new helper methods and improves naming and identification logic for networks and port profiles.

**Coordinator enhancements:**

* Added handling and storage for `port_profiles` and `networks` in the coordinator, including new update methods `_update_port_profiles_in_dict` and `_update_networks_in_dict` to fetch and convert API data to typed objects. [[1]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeR114-R115) [[2]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeR457-R460) [[3]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL460-R480) [[4]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeR596-R597) [[5]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeR909-R951)
* Refactored VPN client/server update logic to derive entities from network data when available, with fallback to API methods. [[1]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL460-R480) [[2]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL809-R875)

**Helper function improvements:**

* Updated `get_rule_enabled`, `get_rule_id`, and `get_rule_prefix` to support `NetworkConf` and `PortProfile` objects, ensuring correct enabled state and unique ID generation. [[1]](diffhunk://#diff-245135ebf17abb8839d54d03c534b1461febbed334f549f0ec1dd3159d1978cfR51-R58) [[2]](diffhunk://#diff-245135ebf17abb8839d54d03c534b1461febbed334f549f0ec1dd3159d1978cfR167-R182) [[3]](diffhunk://#diff-245135ebf17abb8839d54d03c534b1461febbed334f549f0ec1dd3159d1978cfL189-R219)
* Improved `extract_descriptive_name` and `get_rule_name` to generate specialized names for networks (e.g., WAN, VLAN, LAN) and to filter out VPN networks from switch entities. [[1]](diffhunk://#diff-245135ebf17abb8839d54d03c534b1461febbed334f549f0ec1dd3159d1978cfR380-R414) [[2]](diffhunk://#diff-245135ebf17abb8839d54d03c534b1461febbed334f549f0ec1dd3159d1978cfR442-R460)

**Network utility additions:**

* Added `is_vpn_network` and `filter_switchable_networks` helpers to reliably detect and filter VPN networks for entity creation.

**General refactoring and cleanup:**

* Removed unused imports and streamlined error handling in the coordinator, including variable renaming for clarity. [[1]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL11-L14) [[2]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL25-R33) [[3]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL421-R426) [[4]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL604-R621) [[5]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeL997-R1101) [[6]](diffhunk://#diff-81f1817c103d5ff0a3dff3fa90c372bcf857a448bb6b1efb6be3e2f9b526bfbeR676-R677)

These changes collectively improve the integration's support for UniFi network and port profile entities, provide more accurate VPN handling, and make the codebase more maintainable and robust.