### PR TITLE
Fixed issue with change detection for new entity types

### DIFF
--- a/custom_components/unifi_network_rules/coordinator.py
+++ b/custom_components/unifi_network_rules/coordinator.py
@@ -587,7 +587,10 @@ class UnifiRuleUpdateCoordinator(DataUpdateCoordinator):
                     len(rules_data["port_forwards"]) > 0 or
                     len(rules_data["qos_rules"]) > 0 or
                     len(rules_data["traffic_routes"]) > 0 or
-                    len(rules_data["legacy_firewall_rules"]) > 0
+                    len(rules_data["legacy_firewall_rules"]) > 0 or
+                    len(rules_data["port_profiles"]) > 0 or
+                    len(rules_data["networks"]) > 0 or
+                    len(rules_data["devices"]) > 0
                 )
 
                 # Special handling for authentication failures detected during update

--- a/custom_components/unifi_network_rules/unified_change_detector.py
+++ b/custom_components/unifi_network_rules/unified_change_detector.py
@@ -338,6 +338,11 @@ class UnifiedChangeDetector:
                         # This is a typed aiounifi object with raw data
                         entity_data = entity.raw.copy()
                         entity_id = entity_data.get('_id') or entity_data.get('id')
+                        
+                        # For objects with computed properties (like PortProfile.enabled), 
+                        # we need to capture those properties in the state snapshot
+                        if hasattr(entity, 'enabled'):
+                            entity_data['enabled'] = entity.enabled
                     elif isinstance(entity, dict):
                         # This is a raw dictionary
                         entity_data = entity.copy()


### PR DESCRIPTION
- Updated UnifiRuleUpdateCoordinator to include checks for port profiles, networks, and devices in the rules data, improving the completeness of rule updates.
- Modified UnifiedChangeDetector to capture computed properties for entities, specifically adding support for the 'enabled' property in state snapshots, enhancing state management.

This pull request enhances the handling and tracking of additional UniFi network entities and ensures that computed properties are included in state snapshots. The main improvements are focused on expanding the types of data monitored by the coordinator and increasing the accuracy of state comparisons for entities with computed attributes.

**Expanded entity tracking:**
* The coordinator now checks for changes in `port_profiles`, `networks`, and `devices` in addition to the previously tracked entities when determining if there are updates to process.

**Improved state snapshot accuracy:**
* When building state snapshots, the code now explicitly includes computed properties like `enabled` for entities that have them, ensuring that changes to these properties are detected.