### PR TITLE
chore: doc and oak updates

### DIFF
--- a/.claude/skills/codebase-intelligence/SKILL.md
+++ b/.claude/skills/codebase-intelligence/SKILL.md
@@ -124,7 +124,7 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "YOUR QUERY HERE"
 | Table | Purpose | Key Columns |
 |-------|---------|-------------|
 | `memory_observations` | Extracted memories/learnings | `observation`, `memory_type`, `status`, `context`, `tags`, `importance`, `session_origin_type` |
-| `sessions` | Coding sessions (launch to exit) | `id`, `agent`, `status`, `summary`, `title`, `started_at`, `created_at_epoch` |
+| `sessions` | Coding sessions (launch to exit) | `id`, `agent`, `status`, `summary`, `title`, `title_manually_edited`, `started_at`, `created_at_epoch` |
 | `prompt_batches` | User prompts within sessions | `session_id`, `user_prompt`, `classification`, `response_summary` |
 | `activities` | Raw tool executions | `session_id`, `tool_name`, `file_path`, `success`, `error_message` |
 | `agent_runs` | CI agent executions | `agent_name`, `task`, `status`, `result`, `cost_usd`, `turns_used` |

--- a/.claude/skills/codebase-intelligence/SKILL.md
+++ b/.claude/skills/codebase-intelligence/SKILL.md
@@ -130,7 +130,7 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "YOUR QUERY HERE"
 | `agent_runs` | CI agent executions | `agent_name`, `task`, `status`, `result`, `cost_usd`, `turns_used` |
 | `session_link_events` | Session linking analytics | `session_id`, `event_type`, `old_parent_id`, `new_parent_id` |
 | `session_relationships` | Semantic session relationships | `session_a_id`, `session_b_id`, `relationship_type`, `similarity_score` |
-| `agent_schedules` | Cron scheduling state | `task_name`, `cron_expression`, `enabled`, `last_run_at`, `next_run_at` |
+| `agent_schedules` | Cron scheduling state | `task_name`, `cron_expression`, `enabled`, `additional_prompt`, `last_run_at`, `next_run_at` |
 | `resolution_events` | Cross-machine resolution propagation | `observation_id`, `action`, `source_machine_id`, `applied`, `content_hash` |
 <!-- END GENERATED CORE TABLES -->
 

--- a/.claude/skills/codebase-intelligence/references/schema.md
+++ b/.claude/skills/codebase-intelligence/references/schema.md
@@ -2,7 +2,7 @@
 
 Complete DDL for the Oak CI SQLite database at `.oak/ci/activities.db`.
 
-Current schema version: **4**
+Current schema version: **6**
 
 ## memory_observations
 
@@ -53,11 +53,14 @@ CREATE TABLE IF NOT EXISTS sessions (
     processed BOOLEAN DEFAULT FALSE,  -- Has background processor handled this?
     summary TEXT,  -- LLM-generated session summary
     title TEXT,  -- LLM-generated short session title (10-20 words)
+    title_manually_edited BOOLEAN DEFAULT FALSE,  -- Protect manual edits from LLM overwrite
     created_at_epoch INTEGER NOT NULL,
     parent_session_id TEXT,  -- Session this was derived from
     parent_session_reason TEXT,  -- Why linked: 'clear', 'compact', 'inferred'
     source_machine_id TEXT,  -- Machine that originated this record
-    transcript_path TEXT  -- Path to session transcript file for recovery
+    transcript_path TEXT,  -- Path to session transcript file for recovery
+    summary_updated_at INTEGER,  -- Epoch when summary was last generated/updated
+    summary_embedded INTEGER DEFAULT 0  -- Has summary been indexed in ChromaDB?
 );
 ```
 

--- a/.claude/skills/codebase-intelligence/references/schema.md
+++ b/.claude/skills/codebase-intelligence/references/schema.md
@@ -2,7 +2,7 @@
 
 Complete DDL for the Oak CI SQLite database at `.oak/ci/activities.db`.
 
-Current schema version: **3**
+Current schema version: **4**
 
 ## memory_observations
 
@@ -228,6 +228,7 @@ CREATE TABLE IF NOT EXISTS agent_schedules (
     cron_expression TEXT,           -- Cron expression (e.g., '0 0 * * MON')
     description TEXT,               -- Human-readable schedule description
     trigger_type TEXT DEFAULT 'cron', -- 'cron' or 'manual' (future: 'git_commit', 'file_change')
+    additional_prompt TEXT,          -- Persistent assignment prepended to task on each run
 
     -- Runtime state
     last_run_at TEXT,

--- a/.claude/skills/context-engineering/SKILL.md
+++ b/.claude/skills/context-engineering/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: context-engineering
+description: >-
+  Design effective prompts and optimize context for AI models and agents.
+  Covers prompt engineering foundations (clarity, examples, chain of thought,
+  XML structure), the four context engineering strategies (Write, Select,
+  Compress, Isolate), agent memory and session patterns, and before/after
+  examples showing measurable improvement. Use when writing system prompts,
+  designing agent workflows, optimizing context windows, building prompt
+  templates, structuring few-shot examples, reducing context rot, or
+  improving AI output quality.
+allowed-tools: Read
+user-invocable: true
+---
+
+# Context Engineering
+
+Design effective prompts and optimize the full context window for AI models and agents to produce consistently high-quality output.
+
+## Quick Start
+
+### Recipe 1: Improve a vague prompt
+
+**Before:** `Review this code and give feedback.`
+
+**After:**
+```xml
+<task>Review the provided code for correctness, performance, and maintainability.</task>
+<output-format>
+For each issue: file/line, severity (critical|warning|suggestion), problem (one sentence), fix (concrete code change).
+If no issues, state "No issues found" and list one strength.
+</output-format>
+<code>{{code_to_review}}</code>
+```
+
+**Why it works:** Specifies evaluation criteria, defines output structure, separates instructions from data with XML tags.
+
+### Recipe 2: Design a system prompt
+
+Use the **altitude concept** -- not so high it's useless ("be helpful"), not so low it's brittle ("always use 4 spaces").
+
+1. **Define the role** in one sentence: what the agent IS and IS NOT
+2. **Set altitude** -- right level: "Follow the project's existing naming conventions. When none exists, prefer descriptive names over short ones."
+3. **Add constraints** using RFC 2119 language (MUST, SHOULD, MAY)
+4. **Include 1-2 canonical examples** of ideal output
+5. **Define non-goals** to prevent scope creep
+
+See `references/system-prompt-design.md` for full anatomy and templates.
+
+### Recipe 3: Structure agent context with the 4 strategies
+
+When your agent produces inconsistent or degraded output, apply the four strategies:
+
+| Strategy | Action | Example |
+|----------|--------|---------|
+| **Write** | Craft persistent instructions | System prompt with altitude-appropriate rules |
+| **Select** | Choose what enters context | Use `oak_search` to retrieve only relevant code |
+| **Compress** | Reduce tokens, preserve signal | Summarize prior conversation turns, delegate to sub-agents |
+| **Isolate** | Move information out of context | Store reference docs externally, load just-in-time |
+
+```
+1. Start with Write: define a clear system prompt
+2. Apply Select: give the agent only the tools and context it needs
+3. Add Compress: implement compaction for long sessions
+4. Use Isolate: move large reference material behind retrieval
+```
+
+See `references/context-engineering-framework.md` for the full framework.
+
+## The Evolution: Prompt to Context Engineering
+
+| Level | Focus | Scope | Key Insight |
+|-------|-------|-------|-------------|
+| **Basic Prompting** | The question you type | Single user message | Clarity matters |
+| **Prompt Engineering** | Crafting effective prompts | Prompt + examples + structure | Technique amplifies quality |
+| **Context Engineering** | Everything the model sees | System prompt + tools + memory + retrieved docs + conversation history | The context window IS the product |
+
+Context engineering manages **everything** the model sees -- system prompt, tools, retrieved documents, conversation history, and memory. Every token either helps or hurts. The entire context window is a design surface.
+
+## Prompt Engineering Foundations
+
+These eight techniques form the foundation. Master them before moving to context engineering.
+
+| # | Technique | When to Use | Key Rule |
+|---|-----------|-------------|----------|
+| 1 | **Be clear and direct** | Always -- this is the baseline | State exactly what you want; remove ambiguity |
+| 2 | **Use examples (multishot)** | Output format matters, or the task is nuanced | Show 2-3 examples of ideal input/output pairs |
+| 3 | **Chain of thought** | Reasoning, math, multi-step logic | Ask the model to think step-by-step before answering |
+| 4 | **Use XML tags** | Separating instructions from data, structured output | Wrap distinct sections in descriptive tags like `<context>`, `<instructions>` |
+| 5 | **Give Claude a role** | Specialized tasks needing domain expertise | Set the role in the system prompt, not the user message |
+| 6 | **Chain complex prompts** | Multi-step workflows, pipelines | Break into sequential steps; output of step N feeds step N+1 |
+| 7 | **Long context tips** | Large documents, many files | Put key instructions at top and bottom; use XML to delineate sections |
+| 8 | **Extended thinking** | Complex reasoning, planning, self-correction | Enable thinking to let the model plan before responding |
+
+**Combining techniques:** Most effective prompts use 3-5 techniques together. A code review prompt might combine clarity (#1), XML structure (#4), role (#5), and examples (#2).
+
+See `references/prompt-foundations.md` for detailed explanations, examples, and anti-patterns for each technique.
+
+## Context Engineering Framework (4 Strategies)
+
+### Write: Craft the persistent context
+
+The Write strategy covers everything you author in advance: system prompts, tool descriptions, and instruction files. This is the context you control completely.
+
+**The altitude concept** is the most important principle. Your instructions need to be at the right level of abstraction:
+
+| Altitude | Example | Problem |
+|----------|---------|---------|
+| Too high | "Write clean code" | No actionable guidance -- the agent fills in its own interpretation |
+| Too low | "Always use `Array.prototype.reduce` for aggregation" | Brittle -- breaks when context changes, prevents good judgment |
+| Right | "Prefer declarative patterns over imperative loops. Choose the array method that most clearly expresses intent." | Guides without constraining |
+
+**Canonical examples** are powerful -- a single well-chosen example communicates more than paragraphs of rules:
+
+```xml
+<system>
+You generate API documentation from source code.
+<example>
+<input>
+def calculate_tax(amount: float, rate: float = 0.08) -> float:
+    """Calculate sales tax for a given amount."""
+    return round(amount * rate, 2)
+</input>
+<output>
+### `calculate_tax(amount, rate=0.08)`
+Calculate sales tax for a given amount.
+- `amount` (float): The pre-tax amount
+- `rate` (float, optional): Tax rate as decimal. Default: 0.08
+- **Returns:** float -- Tax amount, rounded to 2 decimal places.
+</output>
+</example>
+</system>
+```
+
+**Project-level Write strategy:** Use the `/project-governance` skill to create a constitution (`oak/constitution.md`) and agent instruction files. Your constitution IS your project-level system prompt. The altitude concept applies directly: "write good code" is useless; "copy `src/features/auth/service.py` for new services" is actionable.
+
+See `references/context-engineering-framework.md` for the full Write strategy guide.
+
+### Select: Choose what enters the context window
+
+Select the right information to include; keep everything else out.
+
+**For tools:** Provide the **minimal viable toolset** (unused tools cause confusion), write **unambiguous descriptions** (the model uses these to decide when to call), and prefer **specific tools** over general-purpose ones.
+
+**For retrieved context:** Quality over quantity (3 relevant snippets beat 20 loose ones), recency matters, and always include source attribution (file paths, line numbers).
+
+**Anti-pattern -- context stuffing:**
+```
+# Bad: dumping everything "just in case"
+context = all_docs + all_code + all_history + all_memories
+# Good: selecting what's relevant
+context = search_relevant_code(task) + get_recent_decisions(task)
+```
+
+### Compress: Reduce tokens while preserving information
+
+Compress rather than truncate. Preserve signal while reducing cost.
+
+**Strategies:** Conversation summarization (replace old turns with structured summary), note-taking scratchpad (running notes vs. re-reading history), sub-agent delegation (offload research, return only findings), and tool result cleanup (extract then clear verbose output).
+
+**When to compress:** Context exceeds 50% capacity, agent forgets earlier instructions, responses repeat or lose focus, or tool results contain mostly irrelevant data.
+
+### Isolate: Move information out of the main context
+
+Store information externally and load just-in-time, rather than keeping it in context at all times.
+
+**Patterns:** Just-in-time retrieval (load docs only when needed), progressive disclosure (summary first, details on demand), hybrid context loading (rules in system prompt, reference material behind search), and memory-as-a-tool (store externally, retrieve on demand).
+
+**Progressive disclosure example:** Agent sees summary ("Auth uses JWT") -> needs details (retrieves auth docs) -> needs code (retrieves auth service file). Each step loads only what's needed.
+
+See `references/context-engineering-framework.md` for the complete framework with extended examples.
+
+## Agent Context Patterns
+
+### Sessions vs memory
+
+| Concept | Scope | Lifetime | Purpose |
+|---------|-------|----------|---------|
+| **Session** | Single conversation | Ephemeral | Working memory for the current task |
+| **Memory** | Cross-session | Persistent | Accumulated knowledge and learnings |
+
+The common mistake: keeping everything in the session instead of writing important things to persistent memory.
+
+### Context rot
+
+Output quality degrades as conversations grow longer due to: **dilution** (instructions buried under tool results), **position bias** (models attend more to beginning/end, losing middle), **contradiction accumulation**, and **working memory overflow**.
+
+**Signs:** Agent forgets earlier constraints, responses become generic/repetitive, re-asks answered questions, quality drops vs. early turns.
+
+**Mitigation:** Apply Compress (summarize and compact) and Isolate (move reference material behind retrieval). For long-running agents, implement periodic compaction checkpoints.
+
+### Memory types
+
+| Type | What It Stores | Example | OAK CI Tool |
+|------|---------------|---------|-------------|
+| **Episodic** | What happened | "Refactored auth module in session #42" | `oak_search --type memory` |
+| **Procedural** | How to do things | "To add a feature, copy the strategic_planning exemplar" | `oak_remember` with type `discovery` |
+| **Semantic** | Facts and concepts | "The API uses JWT tokens with 1-hour expiry" | `oak_remember` with type `discovery` |
+
+### Memory-as-a-tool pattern
+
+Store externally, retrieve on demand -- instead of accumulating in context:
+
+```
+1. Discover → oak_remember("auth tokens expire after 1 hour", type="discovery")
+2. Later   → oak_search("auth token expiry") retrieves just-in-time
+3. Stale   → oak_resolve_memory(id, status="resolved") cleans up
+```
+
+This implements both Compress (don't hold everything) and Isolate (retrieve when needed).
+
+### Compaction strategies
+
+| Strategy | How It Works | Best For |
+|----------|-------------|----------|
+| **Last-N** | Keep only the last N conversation turns | Simple, predictable token budget |
+| **Recursive summarization** | Summarize old turns, keep recent ones verbatim | Long conversations with important early context |
+| **Hybrid** | Summarize + keep pinned messages (system prompt, key decisions) | Complex agents with critical persistent instructions |
+
+See `references/agent-context-patterns.md` and `references/memory-and-sessions.md` for detailed patterns and implementation guidance.
+
+## CI Integration: Context Engineering in Practice
+
+OAK's Codebase Intelligence tools directly implement the four context engineering strategies:
+
+| Strategy | CI Tool | What It Does |
+|----------|---------|--------------|
+| **Write** | `oak_remember` / `oak ci remember` | Persist learnings, decisions, and gotchas to long-term memory |
+| **Select** | `oak_search` / `oak ci search` | Retrieve only the code and memories relevant to the current task |
+| **Isolate** | `oak_context` / `oak ci context` | Assemble just-in-time context for a specific task, pulling from code and memory |
+| **Consolidate** | `oak_resolve_memory` / `oak ci resolve` | Resolve stale observations to prevent context rot in the memory store |
+
+### Example workflow
+
+```bash
+# WRITE: Store a discovery for future sessions
+oak ci remember "Payment service retries 3x with exponential backoff" --type discovery
+# SELECT: Find relevant code for a task
+oak ci search "payment retry logic" --type code -n 5
+# ISOLATE: Assemble just-in-time context
+oak ci context "fix payment timeout bug" -f src/services/payment.py
+# CONSOLIDATE: Clean up after fixing
+oak ci resolve <memory-id>
+```
+
+## Before/After Gallery
+
+### Vague prompt to structured prompt
+
+**Before:** `Write tests for the user service.`
+
+**After:**
+```xml
+<task>Write unit tests for UserService: create_user, get_user_by_email, delete_user.</task>
+<constraints>
+- pytest with fixtures for setup/teardown
+- Test success and error paths for each method
+- Mock external API calls (email verification)
+- Descriptive test names: test_create_user_with_duplicate_email_raises_conflict
+</constraints>
+```
+
+### Bloated system prompt to altitude-optimized
+
+**Before** (micromanaging): "Always use f-strings. Always use pathlib. Always use type hints. Use black with line length 88. Use dataclasses for DTOs. Never use print()..."
+
+**After** (right altitude):
+```xml
+<role>You are a Python developer working in this project.</role>
+<principles>
+- Follow existing patterns. Find the closest implementation and mirror its style.
+- Prefer modern Python (3.10+). When in doubt, check what the codebase uses.
+- Write code that reads clearly without comments. Comment only non-obvious "why" decisions.
+</principles>
+<quality>Run `make check` before considering any change complete.</quality>
+```
+
+### Context-stuffed agent to compress + isolate
+
+**Before:** 40,000 tokens (2K rules + 3K README + 8K tool descriptions + 12K API docs + 15K conversation = half irrelevant)
+
+**After:** 8,000 tokens (800 altitude-optimized prompt + 1,200 for 5 relevant tools + 2,000 retrieved context + 4,000 compressed conversation = all relevant)
+
+See `references/before-after-examples.md` for the full gallery with additional transformations.
+
+## When to Use What
+
+| Situation | Strategy | Key Technique | Reference |
+|-----------|----------|---------------|-----------|
+| Writing a new system prompt | Write | Altitude concept, canonical examples | `references/system-prompt-design.md` |
+| Prompt gives inconsistent results | Foundations | Add examples, use XML structure | `references/prompt-foundations.md` |
+| Agent losing track of goals | Compress | Conversation summarization, compaction | `references/context-engineering-framework.md` |
+| Agent context window filling up | Isolate | Just-in-time retrieval, progressive disclosure | `references/agent-context-patterns.md` |
+| Agent forgetting earlier decisions | Write + Compress | Pin critical context, summarize history | `references/memory-and-sessions.md` |
+| Need to measure prompt quality | Evaluate | A/B testing, rubric scoring | `references/evaluation-and-testing.md` |
+| Setting project-wide AI rules | Write | Constitution as system prompt | `/project-governance` skill |
+| Agent repeating mistakes across sessions | Write | Memory-as-a-tool, `oak_remember` | `references/memory-and-sessions.md` |
+| Complex multi-step reasoning | Foundations | Chain of thought, extended thinking | `references/prompt-foundations.md` |
+| Output format is wrong | Foundations | Examples (multishot), XML tags | `references/prompt-foundations.md` |
+
+## Deep Dives
+
+For detailed guidance on specific topics, consult the reference documents:
+
+- **`references/prompt-foundations.md`** -- Core prompt engineering techniques with examples and anti-patterns
+- **`references/context-engineering-framework.md`** -- The four strategies (Write, Select, Compress, Isolate) in depth
+- **`references/agent-context-patterns.md`** -- Sessions, memory types, context rot, and compaction strategies
+- **`references/system-prompt-design.md`** -- System prompt anatomy, the altitude concept, and reusable templates
+- **`references/memory-and-sessions.md`** -- Memory types, the memory-as-a-tool pattern, and OAK CI integration
+- **`references/before-after-examples.md`** -- Extended gallery of prompt and context transformations
+- **`references/evaluation-and-testing.md`** -- Measuring prompt quality, A/B testing, and iterative improvement

--- a/.claude/skills/context-engineering/references/agent-context-patterns.md
+++ b/.claude/skills/context-engineering/references/agent-context-patterns.md
@@ -1,0 +1,508 @@
+# Agent Context Patterns
+
+Context management patterns for AI agents: autonomous systems that take actions over multiple turns, read and write files, call tools, and maintain state across interactions. These patterns draw from Google's "Context Engineering: Sessions & Memory" whitepaper by Kimberly Milam & Antonio Gulli, and from production agent architectures.
+
+---
+
+## Sessions vs Memory
+
+Sessions and memory serve fundamentally different roles in agent context. Conflating them leads to either bloated sessions (stuffing everything into the conversation) or amnesia (losing hard-won knowledge between conversations).
+
+| Concept | Sessions | Memory |
+|---|---|---|
+| Lifetime | Single conversation | Across conversations |
+| Scope | Turn-by-turn interaction | Persistent knowledge |
+| Storage | Conversation history (in-context) | External database or file store |
+| Growth | Linear with turns | Curated, relatively stable |
+| Example | Chat messages, tool results | Learned preferences, past decisions, gotchas |
+
+### Session Architecture
+
+Each session is one continuous interaction with a goal. The session context grows with every turn: user message, assistant response, tool calls and their results.
+
+A well-structured session has three phases:
+
+1. **Start**: Goal is established, relevant context is loaded (system prompt, retrieved memories, relevant files).
+2. **Middle**: Work happens. Tool calls, reasoning, intermediate results accumulate.
+3. **End**: Outcome is reached. Learnings are extracted and stored to memory.
+
+Session metadata worth tracking:
+
+- Start time and duration
+- Agent ID and model used
+- Tools invoked (names and counts)
+- Files read and written
+- Tokens consumed (input + output)
+- Outcome: completed, failed, abandoned
+- Cost (if available)
+
+This metadata becomes the raw material for episodic memory. OAK CI captures this automatically via `agent_runs` and `sessions` tables.
+
+### Session Boundaries
+
+Deciding when to start a new session vs. continue an existing one:
+
+**Start a new session when:**
+- The user's goal has fundamentally changed
+- The previous session ended with a clear outcome
+- Context has grown past the compaction threshold and a clean start is cheaper than summarization
+- A different agent or model is better suited to the new task
+
+**Continue the existing session when:**
+- The new request builds directly on prior work
+- Relevant context (variable bindings, file state, intermediate results) would be lost
+- The user explicitly asks to continue
+
+**Session continuity** (bridging sessions):
+- Generate a session summary at the end of each session
+- Store key decisions, files touched, and open questions
+- Load this summary at the start of the next related session
+- This is cheaper than maintaining a massive continuous context
+
+---
+
+## Context Rot
+
+Context rot is the degradation of model performance as the context window fills. It is **not linear** -- performance holds steady for a while, then falls off a cliff.
+
+### The Degradation Curve
+
+Empirical behavior across major LLMs:
+
+```
+Performance
+  |████████████████████████
+  |                        ████████
+  |                                ████
+  |                                    ███
+  |                                       ██
+  |                                         █
+  |__________________________________________|___
+  0%        30%       50%       70%      100%
+                Context Window Usage
+```
+
+- **0-35% capacity**: Performance is roughly constant. The model handles instructions, history, and retrieval well.
+- **35-65% capacity**: Gradual degradation. The model starts missing details in the middle of context.
+- **65-80% capacity**: Noticeable decline. Instruction-following weakens, hallucinations increase.
+- **80%+ capacity**: Sharp decline. The model may ignore instructions, contradict itself, or lose track of the goal.
+
+These thresholds vary by model and task. Complex reasoning tasks degrade earlier than simple retrieval tasks.
+
+### Position Bias
+
+Models do not attend equally to all positions in the context window:
+
+- **Primacy effect**: Content at the beginning of context (system prompt, first instructions) gets disproportionate attention.
+- **Recency effect**: Content at the end (most recent messages) also gets strong attention.
+- **Lost in the middle**: Content in the middle of a long context receives the least attention.
+
+**Mitigations:**
+
+1. Place critical instructions in the system prompt (beginning of context).
+2. Repeat key instructions or constraints near the end of context, especially after compaction.
+3. Use XML tags or markdown headers to create clear section boundaries -- these act as attention anchors.
+4. When retrieving context, place the most relevant items closest to the current turn (end of context).
+
+### Causes of Context Rot
+
+| Cause | Mechanism | Mitigation |
+|---|---|---|
+| Token accumulation | Context window fills with conversation history | Compaction or summarization before 60% capacity |
+| Instruction dilution | Instructions become a smaller percentage of total context | Repeat key instructions; use XML section tags |
+| Contradictory information | Earlier context conflicts with later corrections | Explicit "latest wins" rules; remove outdated content |
+| Tool result bloat | Verbose tool outputs (file contents, search results) consume tokens | Summarize tool results after processing; drop raw output |
+| Goal drift | Original goal buried under conversation noise | Maintain a goal scratchpad; restate goals after compaction |
+| Retrieval noise | Irrelevant retrieved context dilutes signal | Filter retrieval results aggressively; prefer precision over recall |
+
+---
+
+## Multi-Agent Session Management
+
+When multiple agents collaborate, context management becomes a distributed systems problem. Three fundamental patterns exist.
+
+### Pattern 1: Shared Context
+
+All agents read from and write to the same context window (or shared document).
+
+```
+┌─────────────────────────────────┐
+│        Shared Context           │
+│  ┌───────┐ ┌───────┐ ┌───────┐ │
+│  │Agent A│ │Agent B│ │Agent C│ │
+│  └───────┘ └───────┘ └───────┘ │
+└─────────────────────────────────┘
+```
+
+**Strengths:**
+- All agents see the full picture
+- No communication overhead
+- Simple to implement
+
+**Weaknesses:**
+- Context bloats N times faster (each agent's output adds to shared context)
+- Agents may contradict each other
+- Hard to scale past 2-3 agents
+- No isolation: one agent's verbose output degrades context for all
+
+**Best for:** Small teams of tightly-coupled agents working on the same artifact.
+
+### Pattern 2: Separate Contexts (Isolation)
+
+Each agent has its own context window. Communication happens via structured messages.
+
+```
+┌───────────┐   message   ┌───────────┐
+│  Agent A   │ ──────────→ │  Agent B   │
+│  (own ctx) │ ←────────── │  (own ctx) │
+└───────────┘             └───────────┘
+```
+
+**Strengths:**
+- Each agent gets focused, relevant context
+- No cross-contamination
+- Scales to many agents
+- Agents can use different models optimized for their task
+
+**Weaknesses:**
+- Communication overhead (messages must be explicit)
+- Risk of information loss at boundaries
+- Harder to coordinate complex multi-step work
+
+**Best for:** Diverse tasks where each agent needs specialized context (e.g., one agent researches, another codes, another reviews).
+
+### Pattern 3: Hybrid (Orchestrator + Workers)
+
+An orchestrator agent maintains shared state. Worker agents operate in isolation with task-specific context. Results flow back through the orchestrator.
+
+```
+              ┌──────────────┐
+              │ Orchestrator  │
+              │ (shared state)│
+              └──┬───┬───┬──┘
+                 │   │   │
+          ┌──────┘   │   └──────┐
+          ▼          ▼          ▼
+    ┌──────────┐ ┌──────────┐ ┌──────────┐
+    │ Worker A  │ │ Worker B  │ │ Worker C  │
+    │ (own ctx) │ │ (own ctx) │ │ (own ctx) │
+    └──────────┘ └──────────┘ └──────────┘
+```
+
+**Strengths:**
+- Workers get clean, focused context (no pollution from other workers)
+- Orchestrator maintains the big picture
+- Workers can run in parallel
+- Scales well
+
+**Weaknesses:**
+- Orchestrator context can still bloat if many workers report back
+- Design complexity: must define clear task boundaries and result formats
+
+**Best for:** Production agent systems. This is the pattern used by Claude Code's team mode, OAK's analysis agents, and most multi-agent frameworks.
+
+### Choosing a Pattern
+
+| Factor | Shared | Isolated | Hybrid |
+|---|---|---|---|
+| Number of agents | 2-3 | Any | Any |
+| Task coupling | Tight | Loose | Mixed |
+| Context efficiency | Low | High | High |
+| Implementation effort | Low | Medium | High |
+| Scalability | Poor | Good | Good |
+
+---
+
+## Compaction Strategies
+
+When context grows too large, you must compact it. The strategy you choose determines what knowledge survives compression.
+
+### Strategy 1: Last-N Messages
+
+Keep only the most recent N conversation turns. Discard everything older.
+
+**How it works:**
+```
+Before: [msg1, msg2, msg3, msg4, msg5, msg6, msg7, msg8]
+After (N=4): [msg5, msg6, msg7, msg8]
+```
+
+**Characteristics:**
+- Simple and predictable
+- Token usage is bounded
+- Completely loses early context (instructions, goals, decisions made early)
+- No computation overhead
+
+**Best for:** Stateless chat applications, simple Q&A bots, situations where early context is truly irrelevant.
+
+**Not suitable for:** Multi-step tasks where early instructions or decisions matter.
+
+### Strategy 2: Recursive Summarization
+
+Summarize old messages into a running summary. Keep the summary plus recent messages.
+
+**How it works:**
+```
+Before: [summary_v1, msg4, msg5, msg6, msg7, msg8, msg9, msg10]
+Trigger: context > 60% capacity
+After:  [summary_v2 (covers msg1-msg7), msg8, msg9, msg10]
+```
+
+Where `summary_v2` incorporates `summary_v1` and `msg4-msg7` into a new summary.
+
+**Characteristics:**
+- Preserves a compressed version of all history
+- Moderate token efficiency
+- Risk: summarization losses compound over time (the "telephone game" effect)
+- Each compaction step loses some fidelity
+- Works best when the model doing summarization is high quality
+
+**Implementation guidance:**
+- Trigger summarization at 55-65% context capacity (before degradation begins)
+- Use structured summaries: decisions made, files changed, open questions, key facts
+- Include explicit section for "instructions that must be preserved"
+- Consider having the summary reviewed/approved before discarding originals
+
+### Strategy 3: Manus Hybrid (Structured Scratchpad)
+
+Maintain two zones: a **verbatim zone** (recent turns, kept as-is) and a **summary zone** (older turns, compressed). Alongside both, maintain a **structured scratchpad** that is never summarized.
+
+**How it works:**
+```
+Context layout:
+┌─────────────────────────────┐
+│ System Prompt (fixed)        │
+├─────────────────────────────┤
+│ Scratchpad (preserved)       │
+│  - Current goal              │
+│  - Key facts learned         │
+│  - Decisions made            │
+│  - Open questions            │
+│  - Files modified            │
+├─────────────────────────────┤
+│ Summary Zone (compressed)    │
+│  "Earlier: researched auth   │
+│   options, chose JWT..."     │
+├─────────────────────────────┤
+│ Verbatim Zone (recent turns) │
+│  [msg8, msg9, msg10]         │
+└─────────────────────────────┘
+```
+
+**Characteristics:**
+- Highest context preservation of any compaction strategy
+- The scratchpad acts as a lossless knowledge store across compactions
+- More complex to implement: requires maintaining the scratchpad format
+- The scratchpad itself must be kept concise (it is never compressed)
+
+**Implementation guidance:**
+- Define scratchpad structure upfront (what sections, what format)
+- Update the scratchpad explicitly during the session (not just at compaction time)
+- On compaction: compress the narrative (conversation), but copy the scratchpad verbatim
+- Cap scratchpad size (e.g., 2000 tokens) to prevent it from becoming its own bloat problem
+
+### Strategy Comparison
+
+| Strategy | Context Preservation | Simplicity | Token Efficiency | Compounding Loss | Best For |
+|---|---|---|---|---|---|
+| Last-N | Low | High | High | None (hard cutoff) | Short tasks, chat |
+| Recursive Summarization | Medium | Medium | Medium | Yes (telephone game) | Medium-length sessions |
+| Manus Hybrid | High | Low | Medium | Minimal (scratchpad preserved) | Complex multi-step tasks |
+| Full (no compaction) | Perfect | Highest | Lowest | N/A | Sessions under 30% capacity |
+
+**Rule of thumb:** If your agent sessions routinely exceed 50% context capacity, you need a compaction strategy. If they involve multi-step reasoning or long-running tasks, prefer the Manus Hybrid approach.
+
+---
+
+## Memory Architecture (5 Layers)
+
+From Google's whitepaper, agent memory has five layers, analogous to human memory systems. Each layer has different lifetime, retrieval characteristics, and storage requirements.
+
+### Layer 1: Sensory Memory (Immediate Context)
+
+The current turn's raw input: the user's latest message, tool results just returned, documents just retrieved.
+
+- **Lifetime:** Single turn
+- **Size:** Small (one turn's worth of data)
+- **Analogy:** What you are looking at right now
+- **Implementation:** The latest entries in the conversation messages array
+- **Key concern:** Filter aggressively. Not everything the tools return needs to stay in context.
+
+### Layer 2: Short-Term Memory (Session Context)
+
+The conversation history within the current session. Grows with each turn.
+
+- **Lifetime:** Current session
+- **Size:** Grows linearly; subject to context rot
+- **Analogy:** What you have been thinking about for the last hour
+- **Implementation:** The conversation messages array, subject to compaction
+- **Key concern:** This is where context rot lives. Apply compaction strategies from the previous section.
+
+### Layer 3: Episodic Memory (What Happened)
+
+Records of past events and experiences. Retrieved when relevant to the current task.
+
+- **Lifetime:** Long-term (persists across sessions)
+- **Content:** Specific events: "Last time we refactored the auth module, tests broke because mock setup was order-dependent"
+- **Retrieval:** Semantic search triggered by current task context
+- **OAK CI equivalent:** `memory_observations` with types `bug_fix` and `gotcha`
+- **Key concern:** Must be retrievable by relevance, not just recency. Vector search is preferred.
+
+### Layer 4: Semantic Memory (Facts and Concepts)
+
+General knowledge about the domain, the codebase, or the project. Relatively stable over time.
+
+- **Lifetime:** Long-term, updated infrequently
+- **Content:** "This codebase uses the repository pattern for data access" or "The API rate limit is 100 requests per minute"
+- **Retrieval:** Semantic search, or loaded proactively based on file/topic context
+- **OAK CI equivalent:** `memory_observations` with types `discovery` and `decision`
+- **Key concern:** Keep entries atomic and factual. Vague or compound observations degrade search quality.
+
+### Layer 5: Procedural Memory (How To Do Things)
+
+Skills, procedures, and workflows. The agent's "muscle memory."
+
+- **Lifetime:** Permanent (updated with project evolution)
+- **Content:** "To add a new API endpoint: create route file, add service, write tests, update OpenAPI spec"
+- **Implementation:** System prompts, constitution files, skill files, templates
+- **OAK CI equivalent:** Constitution (`oak/constitution.md`), skill files, agent task definitions
+- **Key concern:** This is the most valuable memory layer. It should be curated by humans, not auto-generated.
+
+### How the Layers Integrate
+
+At each turn, the agent assembles context from all five layers:
+
+```
+Context Assembly (per turn):
+
+  Layer 5: System prompt + skill instructions    [always present, fixed cost]
+      │
+  Layer 4: Retrieved semantic memories           [loaded at session start or on topic change]
+      │
+  Layer 3: Retrieved episodic memories            [searched per-turn based on current task]
+      │
+  Layer 2: Session history (compacted)            [growing, subject to compaction]
+      │
+  Layer 1: Current turn input + tool results      [fresh each turn]
+      │
+      ▼
+  ┌──────────────────┐
+  │  Model Inference  │
+  └──────────────────┘
+```
+
+**Token budget allocation** (approximate, for a 200K-token model):
+
+| Layer | Budget | Notes |
+|---|---|---|
+| Layer 5 (Procedural) | 10-20K tokens | System prompt, skills, constitution |
+| Layer 4 (Semantic) | 5-10K tokens | Retrieved facts, project knowledge |
+| Layer 3 (Episodic) | 3-5K tokens | Relevant past experiences |
+| Layer 2 (Session) | 50-100K tokens | Conversation history (compacted) |
+| Layer 1 (Sensory) | 10-30K tokens | Current tool results, retrieved docs |
+| Reserved for response | 10-30K tokens | Model's output budget |
+
+These are guidelines, not rules. Adjust based on your model's context window and task requirements.
+
+---
+
+## Practical Patterns for Agent Loops
+
+### The Observe-Think-Act-Reflect Loop
+
+The core agent loop with explicit context management at each phase:
+
+**1. Observe** -- Gather context before reasoning.
+- Retrieve relevant memories (`oak_search`, `oak_context`)
+- Read relevant files
+- Check task state and dependencies
+- Load any session scratchpad from prior compaction
+
+**2. Think** -- Reason about the gathered context.
+- Extended thinking / chain-of-thought helps here
+- Consider multiple approaches before acting
+- Identify what additional context might be needed
+
+**3. Act** -- Take action based on reasoning.
+- Write code, call APIs, modify files
+- Use tools to verify results (run tests, check output)
+- Keep tool calls focused: avoid retrieving more context than needed
+
+**4. Reflect** -- Store learnings from the outcome.
+- If something unexpected happened, store it as episodic memory (`oak_remember`)
+- Update the session scratchpad with new facts, decisions, and open questions
+- If a general pattern was discovered, store it as semantic memory
+
+This loop naturally integrates all five memory layers: Layer 5 provides the loop structure itself, Layers 3-4 feed the Observe phase, Layer 2 provides session continuity, and Layer 1 is the current turn's input.
+
+### Context Budget Management
+
+Monitor context usage and trigger compaction proactively:
+
+```
+Per-turn context check:
+
+  current_usage = system_prompt + session_history + retrieval + pending_response
+  capacity = model_context_window
+
+  if current_usage > 0.55 * capacity:
+      trigger_compaction()       # Summarize old turns, preserve scratchpad
+
+  if current_usage > 0.75 * capacity:
+      aggressive_compaction()    # Deeper summarization, drop tool results
+
+  if current_usage > 0.90 * capacity:
+      emergency_compaction()     # Keep only scratchpad + last 3 turns
+```
+
+**Key principle:** Compact early, compact often. It is better to summarize 10 turns when you have headroom than to be forced into emergency compaction that loses critical context.
+
+### Goal Persistence
+
+Goal drift is the most common cause of agent failure in long sessions. The original task gets buried under conversation history and the agent starts optimizing for the wrong thing.
+
+**Mitigations:**
+
+1. **Explicit goal statement**: Store the current goal in the session scratchpad. Not just "fix the bug" but "fix the authentication timeout bug in `auth_service.py` where JWT tokens expire during long-running requests."
+
+2. **Goal restatement**: After every compaction, restate the goal. After every N turns (e.g., 10), restate the goal.
+
+3. **Goal decomposition**: Break complex goals into sub-goals. Track which sub-goals are complete and which remain.
+
+4. **Completion criteria**: Define upfront what "done" looks like. "The fix is done when: (a) the timeout no longer occurs, (b) existing tests pass, (c) a new test covers the edge case."
+
+### When to Store Memories
+
+Not every observation deserves to be a memory. Store memories when:
+
+| Signal | Memory Type | Example |
+|---|---|---|
+| Something broke unexpectedly | `gotcha` | "Mocking `datetime.now()` in this codebase requires patching the module-level import, not `datetime.datetime.now`" |
+| A bug was fixed and the root cause was non-obvious | `bug_fix` | "The flaky test was caused by test ordering -- `test_auth` was leaking a database connection" |
+| An architectural pattern was discovered | `discovery` | "All API routes in this project use the decorator pattern from `base_route.py`" |
+| A deliberate choice was made between alternatives | `decision` | "Chose SQLite over PostgreSQL for CI data because it requires zero configuration and the data is machine-local" |
+| A trade-off was identified | `trade_off` | "Compacting at 55% capacity loses less context but triggers more frequent compactions, increasing latency" |
+
+**Do not store:**
+- Obvious facts anyone could find by reading the code
+- Session-specific state that will not be relevant later
+- Speculative conclusions from reading a single file
+- Anything already documented in the project's constitution or README
+
+---
+
+## Key Takeaways
+
+1. **Sessions are ephemeral; memory is durable.** Do not try to make sessions do the job of memory, or vice versa.
+
+2. **Context rot is non-linear.** Performance holds steady, then falls off a cliff. Compact before you hit the cliff, not after.
+
+3. **Position matters.** Put critical instructions at the start and end of context. Use structural markers (XML tags, headers) to create attention anchors.
+
+4. **Prefer the hybrid pattern** for multi-agent systems. Isolation protects each agent's context quality; the orchestrator maintains coherence.
+
+5. **Compaction is not optional** for long-running agents. Choose a strategy that preserves structured knowledge (decisions, goals, facts) even as narrative history is compressed.
+
+6. **Memory has layers.** Procedural memory (skills, constitution) is the most valuable. Episodic memory (what happened) is the most underused. Invest in both.
+
+7. **Goals drift. State them explicitly, restate them often.** A scratchpad with the current goal, sub-goals, and completion criteria prevents the most common mode of agent failure.

--- a/.claude/skills/context-engineering/references/before-after-examples.md
+++ b/.claude/skills/context-engineering/references/before-after-examples.md
@@ -1,0 +1,331 @@
+# Before/After Examples
+
+Concrete transformations showing how context engineering techniques improve real prompts. Each example: **Before** (problematic), **Diagnosis** (what's wrong), **Techniques Applied**, **After** (improved).
+
+---
+
+## 1. Vague Prompt to Structured Prompt
+
+### Before
+```
+Help me with this code. It's not working right and I need it fixed.
+```
+
+### Diagnosis
+- "Not working" gives zero actionable detail -- no code, no error, no expected behavior
+- No output format specified
+
+### Techniques Applied
+- **Be Clear and Direct**: state the exact problem and expected vs actual behavior
+- **XML Tags**: separate code, error, and instructions
+
+### After
+```xml
+<code language="python">
+def calculate_discount(price, tier):
+    if tier == "gold": return price * 0.8
+    if tier == "silver": return price * 0.9
+    return price
+</code>
+
+<error>calculate_discount(100, "Gold") returns 100 instead of 80.</error>
+
+<instructions>
+1. Identify why the function fails for "Gold" (capital G)
+2. Fix the bug
+3. Add handling for invalid tier values (return price unchanged, log a warning)
+</instructions>
+
+<output_format>Root cause (one sentence), fixed code, test cases.</output_format>
+```
+
+**Why it works:** The model knows exactly what is broken, what the expected behavior is, and what to produce. No ambiguity about scope or success criteria.
+
+---
+
+## 2. Wall of Text to XML-Structured Context
+
+### Before
+```
+Here's my API spec and some error logs and the database schema. The API
+spec says we have a /users endpoint that accepts POST with name and email.
+The email should be unique. Here are the error logs: [2024-01-15 14:23:01]
+IntegrityError: duplicate key violates "users_email_key" Request: POST
+/users {"name": "Jane", "email": "jane@test.com"} And the schema is
+CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT
+NOT NULL UNIQUE). Why am I getting these errors?
+```
+
+### Diagnosis
+- Three data sources in one paragraph with no separation
+- Question buried at the end -- model reads data without knowing the goal
+
+### Techniques Applied
+- **XML Tags**: each data source in its own labeled section
+- **Long Context Tips**: front-load the question
+
+### After
+```xml
+<question>
+Why do duplicate key errors occur on POST /users? Provide: root cause, fix, error response.
+</question>
+
+<error_logs>
+[2024-01-15 14:23:01] IntegrityError: duplicate key violates "users_email_key"
+  Request: POST /users {"name": "Jane", "email": "jane@test.com"}
+[2024-01-15 14:25:12] IntegrityError: duplicate key violates "users_email_key"
+  Request: POST /users {"name": "John", "email": "jane@test.com"}
+</error_logs>
+
+<database_schema>
+CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL UNIQUE);
+</database_schema>
+
+<api_spec>POST /users — Body: { name, email } — email must be unique</api_spec>
+```
+
+**Why it works:** Each data source is labeled. The question is front-loaded so the model reads data with the goal already in mind.
+
+---
+
+## 3. Bloated System Prompt to Altitude-Optimized
+
+### Before (22 generic directives)
+```
+You are an AI assistant. Be helpful, harmless, honest. Be polite.
+Use clear language. Be concise but thorough. Prioritize accuracy.
+Always cite sources. Be creative when appropriate. Ask clarifying
+questions. Be empathetic. Use examples. Stay on topic. [... 10 more ...]
+```
+
+### Diagnosis
+- None specific enough to change behavior -- "be helpful" is default
+- Contradictions: "be concise" vs "be thorough"
+- No role, no domain, no output conventions
+
+### Techniques Applied
+- **Altitude optimization**: raise to principled guidance
+- **System prompt design**: define role with domain expertise
+
+### After
+```xml
+<role>
+Code reviewer. Domain: Django REST APIs with PostgreSQL. Senior level.
+</role>
+
+<constraints>
+- Flag security issues as CRITICAL regardless of other priorities
+- If a change affects schema, always mention migration safety
+- When trade-offs exist, state both options and recommend one
+- Say "I'm not sure" rather than guessing on library-specific behavior
+</constraints>
+
+<output_conventions>
+- Reference file:line_number for each finding
+- Severity: CRITICAL, WARNING, SUGGESTION
+- Include corrected code for CRITICAL and WARNING items
+</output_conventions>
+```
+
+**Why it works:** 22 vague directives became 7 specific rules. Generic advice is gone; domain-specific guidance takes its place.
+
+---
+
+## 4. Context-Stuffed Agent to Compress and Isolate
+
+### Before
+```
+System prompt permanently includes:
+- Full API docs (8K tokens), database schema (3K), error codes (2K),
+  coding standards (1.5K), changelog (4K) = ~18,500 tokens always loaded
+```
+
+### Diagnosis
+- Most reference data used rarely (~5% per conversation)
+- 18K tokens permanently occupied; position bias weakens middle sections
+- Stale data in the system prompt is worse than no data
+
+### Techniques Applied
+- **Isolate**: move reference data behind tool calls
+- **Compress**: summarize what remains
+- **Select**: retrieve only what the current query needs
+
+### After
+```
+System prompt (800 tokens): role, principles, tool instructions
+
+Tools:
+- search_api_docs(endpoint) -> docs for one endpoint
+- query_schema(table_name) -> schema for one table
+- lookup_error_code(code) -> one error definition
+- get_coding_standards(topic) -> relevant standards
+```
+
+**Why it works:** 18,500 to 800 tokens (95% reduction). Data always current (retrieved live). Model attention focused. Cost drops proportionally.
+
+---
+
+## 5. Stateless Agent to Memory-Augmented
+
+### Before
+```
+User: "Can you help me with the auth module?"
+Agent: Starts from scratch. Doesn't know about the circular import
+       bug fixed last week or the refactor merged yesterday.
+```
+
+### Diagnosis
+- No persistent memory -- each session reinvents the wheel
+- Same gotchas hit repeatedly; user re-explains context every time
+
+### Techniques Applied
+- **Write**: store observations as they emerge
+- **Select**: retrieve relevant memories at session start
+
+### After
+```
+Session start: Agent receives injected context:
+  - Recent session summaries, active gotchas, unresolved observations
+
+During work: Agent stores learnings:
+  oak_remember("Auth circular import caused by module-level import
+  of UserModel. Fixed by moving inside function.",
+  memory_type="bug_fix", context="src/services/auth_service.py")
+
+Next session: "Help with the auth module?"
+  Agent already knows about the circular import and last week's refactor.
+```
+
+**Why it works:** The agent compounds knowledge across sessions. Gotchas caught once stay caught.
+
+---
+
+## 6. Poor Few-Shot to Diverse Multishot
+
+### Before (2 trivial examples)
+```
+Convert descriptions to SQL queries.
+Example: "Get all users" -> SELECT * FROM users;
+Example: "Get active users" -> SELECT * FROM users WHERE active = true;
+Now convert: "Get the top 5 customers by total spending last quarter"
+```
+
+### Diagnosis
+- 2 examples, both trivially simple (single table, no joins)
+- Actual task requires JOIN, GROUP BY, ORDER BY, LIMIT, date filtering
+- No schema -- model guesses table and column names
+
+### Techniques Applied
+- **Multishot examples**: 5 diverse examples, simple to complex
+- **XML Tags**: structure examples and provide schema
+
+### After
+```xml
+Convert natural language to PostgreSQL using this schema:
+
+<schema>
+users(id, name, email, created_at)
+orders(id, user_id, total_amount, created_at, status)
+products(id, name, price, category)
+order_items(order_id, product_id, quantity)
+</schema>
+
+<examples>
+<example>
+<input>Get all users</input>
+<output>SELECT * FROM users;</output>
+</example>
+<example>
+<input>Active orders with user names</input>
+<output>SELECT u.name, o.id, o.total_amount
+FROM orders o JOIN users u ON u.id = o.user_id WHERE o.status = 'active';</output>
+</example>
+<example>
+<input>Count orders per user, highest first</input>
+<output>SELECT u.name, COUNT(o.id) AS order_count
+FROM users u LEFT JOIN orders o ON o.user_id = u.id
+GROUP BY u.id, u.name ORDER BY order_count DESC;</output>
+</example>
+<example>
+<input>Revenue by product category this year</input>
+<output>SELECT p.category, SUM(oi.quantity * p.price) AS revenue
+FROM order_items oi JOIN products p ON p.id = oi.product_id
+JOIN orders o ON o.id = oi.order_id
+WHERE o.created_at >= DATE_TRUNC('year', CURRENT_DATE)
+GROUP BY p.category ORDER BY revenue DESC;</output>
+</example>
+<example>
+<input>Users who never placed an order</input>
+<output>SELECT u.name, u.email FROM users u
+LEFT JOIN orders o ON o.user_id = u.id WHERE o.id IS NULL;</output>
+</example>
+</examples>
+
+<input>Get the top 5 customers by total spending last quarter</input>
+```
+
+**Why it works:** Examples progress simple to complex, covering JOINs, GROUP BY, LEFT JOIN for negation, date functions. Schema is explicit.
+
+---
+
+## 7. Unconstrained Output to Prefilled and Formatted
+
+### Before
+```
+Analyze this error log and tell me what happened.
+[error log contents]
+```
+
+### Diagnosis
+- No output structure -- could be a paragraph, list, or narrative
+- "What happened" is open-ended; no actionable structure
+
+### Techniques Applied
+- **Output format**: define exact structure expected
+- **Be Clear and Direct**: bound the scope of analysis
+
+### After
+```xml
+<instructions>
+Analyze this error log. Identify root cause, impact, and fix.
+Respond in exactly this JSON format -- no additional commentary.
+</instructions>
+
+<error_log>[error log contents]</error_log>
+
+<output_format>
+{
+  "root_cause": {
+    "error": "specific error message",
+    "location": "file:line or service",
+    "explanation": "one sentence"
+  },
+  "impact": {
+    "user_facing": "what the user experienced",
+    "scope": "affected users/requests if determinable"
+  },
+  "fix": {
+    "immediate": "what to do now",
+    "preventive": "what to change to prevent recurrence"
+  }
+}
+</output_format>
+```
+
+**Why it works:** The JSON schema acts as a contract. The model produces parseable output, and the three-part structure ensures analysis is actionable, not just descriptive.
+
+---
+
+## Pattern Summary
+
+| Transformation | Key Technique | Typical Improvement |
+|---|---|---|
+| Vague to Structured | Clarity + XML tags | Consistent, relevant responses |
+| Wall of text to XML sections | XML structure | Better information extraction |
+| Low altitude to Right altitude | Altitude optimization | Smaller prompt, better adherence |
+| Context-stuffed to Tool-based | Isolate + Select | 90%+ token reduction, fresher data |
+| Stateless to Memory-augmented | Write + Select | Compounding effectiveness over time |
+| Single example to Diverse multishot | Multishot examples | Edge case handling, format consistency |
+| Unconstrained to Formatted | Output format + Prefill | Parseable, actionable output |
+
+Each transformation applies techniques from [Prompt Engineering Foundations](prompt-foundations.md). For system-level patterns, see [System Prompt Design](system-prompt-design.md). For agent-specific strategies, see [Agent Context Patterns](agent-context-patterns.md).

--- a/.claude/skills/context-engineering/references/context-engineering-framework.md
+++ b/.claude/skills/context-engineering/references/context-engineering-framework.md
@@ -1,0 +1,255 @@
+# The Context Engineering Framework
+
+Context engineering is designing the complete information environment a model receives at inference time. Four core strategies — Write, Select, Compress, Isolate — ensure the model has the right information, in the right form, at the right moment.
+
+## The Core Insight
+
+Context engineering is not prompt engineering. A prompt is what you type. Context is *everything* the model sees: system prompt + conversation history + tool definitions + tool results + retrieved documents + injected memories + file contents + structured metadata.
+
+A well-engineered prompt inside poorly-engineered context will underperform. A mediocre prompt inside well-engineered context will often succeed. **The context is the product.**
+
+The question shifts from "What should I tell the model?" to "What should the model see, and when should it see it?"
+
+---
+
+## Strategy 1: Write — Craft the Persistent Context
+
+The system prompt persists across every turn, anchoring behavior, tone, and decision-making. It is the highest-leverage piece of context.
+
+### The Altitude Scale
+
+Altitude is the level of abstraction at which you write instructions. Most system prompts fail because they target the wrong altitude.
+
+| Level | Example | Problem |
+|---|---|---|
+| Too High (30,000 ft) | "Be a helpful coding assistant" | No actionable guidance |
+| Too Low (ground level) | "Always use 4-space indentation, prefer f-strings over .format(), use pathlib instead of os.path" | Brittle, doesn't generalize, model may ignore the list |
+| Right Altitude (10,000 ft) | "Follow the project's existing code style. When uncertain, match the patterns in nearby files." | Principled, adaptable, scales to new situations |
+
+Right-altitude examples across domains:
+
+| Domain | Too High | Right Altitude |
+|---|---|---|
+| Code review | "Review code carefully" | "Identify bugs that would cause runtime failures, focusing on edge cases the author likely didn't test" |
+| Customer support | "Help the customer" | "Acknowledge the customer's specific situation before moving to resolution. Gather account info early." |
+| Data analysis | "Analyze this data" | "Check for quality issues first (missing values, type mismatches), then answer using appropriate aggregations" |
+| Writing | "Help me write" | "Match the style of the user's existing text. Preserve their voice; improve clarity without imposing a formula." |
+
+**The altitude test:** If your instruction would still be correct after the codebase or domain changes significantly, it is at the right altitude. If it would break, it is too low. If it provides no guidance for concrete decisions, it is too high.
+
+### Canonical Examples in System Prompts
+
+Instructions tell the model what to do. Examples *show* it. When the two conflict, examples usually win — models pattern-match on demonstrations more reliably than they follow abstract rules.
+
+Include 2-3 gold-standard input/output pairs directly in the system prompt:
+
+```
+You are a code review assistant.
+
+## Example Review
+
+**Input code:**
+def get_user(id):
+    user = db.query(f"SELECT * FROM users WHERE id = {id}")
+    return user[0]
+
+**Your review:**
+1. **SQL injection** (critical): Use parameterized queries:
+   `db.query("SELECT * FROM users WHERE id = ?", [id])`
+2. **Unhandled empty result** (bug): `user[0]` raises IndexError
+   if no user matches. Check the result length first.
+3. **Naming**: `id` shadows the built-in. Use `user_id`.
+
+Apply this structure: prioritize by severity, explain the why, show the fix.
+```
+
+This single example establishes the review structure, severity ordering, inline-fix convention, and explanatory tone — all by demonstration.
+
+### System Prompt as Constitution
+
+A system prompt can function as a constitution: a governing document establishing principles, boundaries, and quality standards for an entire project.
+
+> Cross-reference: The `/project-governance` skill creates constitutions that serve exactly this purpose — the Write strategy applied at project scale.
+
+---
+
+## Strategy 2: Select — Choose What Enters the Context
+
+Every token in the context window competes for the model's attention. Select ensures only high-value, relevant information occupies that space.
+
+### Minimal Viable Toolsets
+
+Fewer, well-described tools lead to better tool selection. Tool sprawl causes selection errors and wastes tokens.
+
+| Quality | Tool Description | Issue |
+|---|---|---|
+| Bad | "search: A tool for searching" | What does it search? What format? |
+| Bad | "find_and_replace_in_files: Searches and optionally replaces, supports regex, globs, recursive traversal" | Two tools in one |
+| Good | "grep_codebase: Search file contents with regex. Returns matching lines with file paths and line numbers." | Clear scope, output, use case |
+| Good | "edit_file: Replace a specific string in a file. old_string must appear exactly once." | Precise contract |
+
+**Principles:** single responsibility per tool, verb-based names, remove overlapping tools, conditionally load rarely-used tools.
+
+### Retrieval Quality
+
+RAG is the Select strategy operationalized. Quality matters far more than quantity.
+
+**Precision over recall.** Injecting 20 vaguely-related documents is worse than 3 highly relevant ones. Irrelevant results actively mislead by introducing noise that competes with signal.
+
+Key practices: re-rank after initial retrieval, limit to top-K (typically 3-5), chunk at semantic boundaries (sections, functions) not fixed token counts, test retrieval quality independently.
+
+### Dynamic Context Selection
+
+Route queries to different context sources based on what the query needs:
+
+```
+"I was charged twice"       -> billing KB + account lookup tool
+"App crashes on login"      -> troubleshooting docs + error log tool
+"How do I export my data?"  -> product docs + feature guide
+"I want to cancel"          -> retention playbook + account status tool
+```
+
+Implementation patterns: classify-then-select (two-step), model self-selection via tool descriptions, metadata pre-filtering, or combinations of these.
+
+---
+
+## Strategy 3: Compress — Reduce Without Losing
+
+Conversations grow. Tool results are verbose. Left unchecked, context fills and performance degrades. Compress fights context bloat while preserving essential information.
+
+### Compaction Techniques
+
+| Technique | How It Works | When to Use |
+|---|---|---|
+| Summarization | LLM summarizes older conversation history | Long conversations approaching limits |
+| Note-taking scratchpad | Agent writes key findings to a persistent scratchpad | Complex research tasks |
+| Sub-agent delegation | Spawn focused sub-agents with narrow context; receive only conclusions | Multi-domain tasks |
+| Tool result clearing | Replace verbose tool output with summary after processing | Large tool responses |
+| Recursive summarization | Summarize existing summaries | Very long sessions |
+
+### The Two-Phase Compression Approach
+
+A production pattern combining techniques:
+
+**Phase 1 — Sliding window:** Keep the last N messages verbatim (active working context).
+
+**Phase 2 — Structured summarization:** Compress older messages into: key facts established, decisions made with rationale, open questions, constraints discovered.
+
+This preserves detail where it matters most (recent context) while retaining essentials from earlier. Maintaining a "facts learned" scratchpad alongside the conversation enhances this — the scratchpad becomes a compressed representation of the entire session's knowledge.
+
+### Token Budget Analysis
+
+Budget tokens deliberately rather than filling the window opportunistically.
+
+```
+Available context = Window size - system prompt - tool descriptions
+                  - conversation history - retrieved docs - response budget
+```
+
+| Component | 8K | 32K | 128K | 200K |
+|---|---|---|---|---|
+| System prompt | 1,000 (12%) | 2,000 (6%) | 4,000 (3%) | 5,000 (2.5%) |
+| Tool descriptions | 500 (6%) | 1,500 (5%) | 3,000 (2%) | 4,000 (2%) |
+| Conversation | 2,500 (31%) | 12,000 (37%) | 50,000 (39%) | 80,000 (40%) |
+| Retrieved docs | 1,500 (19%) | 8,000 (25%) | 35,000 (27%) | 55,000 (27.5%) |
+| **Response budget** | **2,500 (31%)** | **8,500 (27%)** | **36,000 (28%)** | **56,000 (28%)** |
+
+**Rules:** Reserve 20-30% for response (truncation degrades quality). Compress proactively, not reactively. System prompt and tool descriptions are fixed costs; conversation and retrieved docs are where compression pays off.
+
+---
+
+## Strategy 4: Isolate — Move Information Out of Main Context
+
+The most powerful strategy for scaling. Move information to external storage, retrieve just-in-time. The context window becomes working memory, not permanent storage.
+
+### Just-in-Time Retrieval
+
+Don't load information until the model needs it.
+
+**Anti-pattern — eager loading:**
+```
+System prompt: full API docs (15K tokens) + style guide (3K)
+  + project rules (5K) + DB schema (4K) = 27K tokens before the user speaks
+```
+
+**Pattern — just-in-time:**
+```
+System prompt: role (200 tokens) + principles (300 tokens)
+  + tools: search_docs(), get_schema(), check_style() = 800 tokens
+  → detailed info retrieved on demand
+```
+
+97% fewer system prompt tokens, access to the same (or more) information.
+
+### Progressive Disclosure
+
+Structure information in layers:
+
+- **Layer 1 — Overview** (always in context): project structure, directory summaries
+- **Layer 2 — Details** (retrieved on demand): file listings with descriptions, section contents
+- **Layer 3 — Raw data** (retrieved for specific work): full file contents, complete records
+
+Each layer provides enough information to decide whether to go deeper — like navigating from a map to a neighborhood to a specific building.
+
+### Hybrid Context Loading
+
+- **Static context** (every turn): system prompt, core tools, persistent memory
+- **Dynamic context** (query-dependent): retrieved documents, relevant code files, user info
+- **Ephemeral context** (use once, then clear): raw tool results, intermediate search results, verbose API responses
+
+Most context is ephemeral — needed for one step, then dead weight. Actively managing context lifecycle (load, use, summarize, clear) keeps the window focused.
+
+---
+
+## Combining Strategies
+
+The four strategies work together. Decision framework:
+
+```
+Is the information needed on EVERY turn?
++-- Yes -> WRITE it into the system prompt
+|   +-- System prompt too long?
+|       +-- Yes -> Raise ALTITUDE or move specifics to retrieval
+|       +-- No  -> Keep it
++-- No -> Needed on SOME turns?
+    +-- Yes -> Can you predict WHEN?
+    |   +-- Yes -> SELECT (pre-filter by query type or metadata)
+    |   +-- No  -> ISOLATE (let model retrieve via tools)
+    +-- Rarely -> COMPRESS or remove entirely
+```
+
+**Combinations in practice:**
+
+| Scenario | Strategies |
+|---|---|
+| Long coding session | Write (project principles) + Isolate (file contents via tools) + Compress (summarize old turns) |
+| RAG-powered Q&A | Write (role + format) + Select (top-K docs) + Compress (multi-retrieval summaries) |
+| Research agent | Write (methodology) + Isolate (search tools) + Compress (scratchpad) + Select (curate findings) |
+| Customer support | Write (tone + policy) + Select (route to relevant KB) + Isolate (account lookup) |
+
+---
+
+## Measuring Context Quality
+
+| Signal | Likely Cause | Action |
+|---|---|---|
+| Model ignores instructions | System prompt too long or low altitude | Raise altitude, compress, move details to retrieval |
+| Wrong tool selected | Ambiguous or overlapping descriptions | Rewrite descriptions, reduce tool count |
+| Hallucinated information | Missing context | Add retrieval, improve selection |
+| Repetitive responses | Context rot (stale/redundant info) | Compress history, deduplicate |
+| Slow responses | Context too large | Compress, isolate verbose data |
+| Contradictory behavior | Conflicting instructions | Audit for contradictions, set precedence |
+| Degraded quality over time | Window filling with low-value history | Sliding-window compression, scratchpad |
+
+### Quick Diagnostic Checklist
+
+When agent performance drops, check in order:
+
+1. **System prompt over 3,000 tokens?** Raise altitude or isolate details.
+2. **More than 15 tools defined?** Reduce, merge, or conditionally load.
+3. **Conversation history over 50% of window?** Compress.
+4. **Retrieved documents relevant?** Spot-check what was actually injected.
+5. **Response budget sufficient?** Ensure 20-30% of window remains for output.
+6. **Contradictions present?** Search full context for conflicting instructions.
+
+Context engineering is iterative. Measure signals, diagnose root causes, apply strategies, measure again.

--- a/.claude/skills/context-engineering/references/evaluation-and-testing.md
+++ b/.claude/skills/context-engineering/references/evaluation-and-testing.md
@@ -1,0 +1,178 @@
+# Evaluation and Testing
+
+How to measure whether your context engineering is working and systematically improve it.
+
+---
+
+## Measuring Context Quality
+
+### Output Quality Dimensions
+
+| Dimension | What It Measures | How to Assess |
+|---|---|---|
+| Accuracy | Are facts and code correct? | Compare against ground truth, run tests |
+| Completeness | Does the response address the full request? | Checklist against requirements |
+| Consistency | Are responses stable across similar inputs? | Run same prompt 5-10 times, compare |
+| Relevance | Is the response focused on what was asked? | Check for tangential content |
+| Efficiency | Minimal tokens for maximum value? | Measure response length vs info density |
+| Format Compliance | Does output match specified format? | Validate against schema/template |
+
+Score each dimension independently on a 1-5 scale. A single aggregate score hides problems — a response can be accurate but verbose, or well-formatted but incomplete.
+
+### Context Quality Signals
+
+When outputs are poor, the cause is often in the context, not the model.
+
+| Signal | Indicates | Action |
+|---|---|---|
+| Model ignores late instructions | Position bias, context too long | Move instructions to start, add XML structure |
+| Hallucinated function names | Missing code context | Improve retrieval, add relevant files |
+| Generic responses | System prompt too high altitude | Lower altitude with more specific guidance |
+| Overly rigid responses | System prompt too low altitude | Raise altitude to principles |
+| Wrong tool selected | Ambiguous tool descriptions | Rewrite descriptions, reduce tool count |
+| Repeated similar answers | Context rot | Compress conversation, add diversity cues |
+| Contradicting earlier responses | Compaction lost key info | Improve compaction strategy, preserve decisions |
+
+---
+
+## A/B Testing Prompts
+
+### The Process
+1. **Baseline**: Run current prompt on 20-50 test cases, record outputs
+2. **Variant**: Modify one aspect of the prompt (not multiple changes at once)
+3. **Evaluate**: Score both sets on the quality dimensions above
+4. **Compare**: Statistical comparison (is the improvement consistent?)
+5. **Iterate**: Keep winner, test next hypothesis
+
+### What to A/B Test
+- System prompt wording (altitude changes)
+- Example selection (different multishot examples)
+- Output format instructions
+- XML structure vs plain text instructions
+- Tool descriptions
+- Context selection (which documents to include)
+- Compaction strategies
+
+### Single Variable Testing
+
+Change ONE thing at a time. If you change both the system prompt AND the examples, you can't attribute improvement to either change.
+
+| Round | Change | Measure |
+|---|---|---|
+| 1 | Add XML structure to prompt | Consistency, format compliance |
+| 2 | Add 3 multishot examples | Accuracy, edge case handling |
+| 3 | Raise system prompt altitude | Generalization, brevity |
+| 4 | Add retrieval for context | Accuracy, completeness |
+
+**Sample size matters.** Test on 20+ inputs to distinguish real improvement from noise. Record results for each round:
+
+```
+Round: 3
+Change: Replaced step-by-step instructions with principles
+Baseline: Accuracy 4.2, Completeness 3.8, Relevance 3.5
+Variant:  Accuracy 4.0, Completeness 3.6, Relevance 4.1
+Decision: Keep — relevance improved; add examples to recover completeness
+```
+
+---
+
+## Memory Metrics
+
+### Precision and Recall
+- **Precision**: Of the memories retrieved, how many were actually relevant?
+  - Low precision = noisy retrieval, irrelevant context injected
+  - Fix: Better embedding model, stricter similarity thresholds, re-ranking
+
+- **Recall**: Of the relevant memories that exist, how many were retrieved?
+  - Low recall = useful memories missed
+  - Fix: Better query formulation, lower similarity thresholds, multiple search strategies
+
+### Recall@K
+- Of the relevant memories, how many appear in the top K results?
+- Recall@5 is most important — agents rarely use more than 5 retrieved items effectively
+- Target: Recall@5 > 0.7 for your most common query types
+
+### Memory Quality Indicators
+
+| Metric | Healthy Range | Warning Sign |
+|---|---|---|
+| Active observations | Growing slowly | Explosive growth (>50/week) = low quality |
+| Resolution rate | 10-20% per month | 0% = never maintaining, >50% = storing too much trivia |
+| Retrieval relevance | >70% relevant in top 5 | <50% = classification or embedding problems |
+| Memory types distribution | Mix of all types | 90%+ one type = narrow capture |
+| Duplicate rate | <5% | >10% = not searching before storing |
+
+---
+
+## Iterative Improvement Workflow
+
+### The Feedback Loop
+
+```
+1. Identify a failure mode (wrong output, missed info, hallucination)
+   |
+   v
+2. Diagnose root cause (bad prompt? missing context? wrong retrieval?)
+   |
+   v
+3. Hypothesize fix (raise altitude? add examples? improve retrieval?)
+   |
+   v
+4. Apply ONE change
+   |
+   v
+5. Test on the original failure case + 5-10 similar cases
+   |
+   v
+6. Did it improve without regressing other cases?
+   |-- Yes -> Keep change, go to step 1 with next failure mode
+   |-- No  -> Revert change, try different hypothesis (step 3)
+```
+
+### Failure Mode to Root Cause Mapping
+
+| Failure Mode | Likely Root Cause | First Fix to Try |
+|---|---|---|
+| Model ignores instructions | Context too long, instructions buried | Compress context, move instructions to system prompt start |
+| Inconsistent output format | No examples of expected format | Add 3 multishot examples with exact output format |
+| Hallucinated information | Model lacking context it needs | Add retrieval (RAG) for the missing knowledge |
+| Correct but verbose | No conciseness instruction | Add explicit length/brevity constraint |
+| Handles common cases, fails edge cases | Examples only show happy path | Add edge case examples (2-3 tricky inputs) |
+| Works for simple queries, fails complex | Single-shot overload | Chain into multiple steps, add CoT |
+| Uses wrong tool | Tool descriptions overlap | Rewrite descriptions to be mutually exclusive |
+| Starts strong, degrades over time | Context rot | Add compaction at 60% capacity, repeat key instructions |
+| Different result each time | Underdetermined prompt | Add more constraints, examples, or structured output format |
+
+Prioritize fixes by **frequency** (how often it occurs), **severity** (how bad the outcome is), and **fixability** (can you address the root cause?). Fix high-frequency, high-severity issues first.
+
+---
+
+## Common Failure Modes
+
+| Failure Mode | Symptom | Category | Remedy |
+|---|---|---|---|
+| Prompt injection | Model ignores system prompt | Security | Input sanitization, separate user/system context |
+| Context overflow | Truncated or missing information | Capacity | Compress, isolate, select less |
+| Stale retrieval | Outdated information surfaces | Memory | Resolve/supersede old observations, refresh index |
+| Over-retrieval | Too many results injected | Selection | Stricter top-K, re-ranking |
+| Under-retrieval | Relevant information not found | Selection | Better embeddings, query expansion |
+| Goal drift | Agent forgets original task | Session | Goal scratchpad, periodic restatement |
+| Tool abuse | Model calls tools unnecessarily | Selection | Fewer tools, clearer descriptions |
+| Format drift | Output format degrades over conversation | Compression | Repeat format instructions after compaction |
+| Anchor bias | First example dominates outputs | Examples | Diverse examples, put the "typical" case second |
+| Sycophancy | Model agrees with incorrect user statements | System prompt | Add "push back when the user is wrong" instruction |
+
+---
+
+## Testing Checklist
+
+Before deploying a prompt/context configuration:
+
+- [ ] Tested on 10+ diverse inputs (not just the examples used in the prompt)
+- [ ] Edge cases covered: empty input, very long input, ambiguous input, off-topic input
+- [ ] Output format consistent across all test cases
+- [ ] No hallucinated information in any test output
+- [ ] Performance acceptable within token/cost budget
+- [ ] Compaction tested: still works after 20+ turns of conversation
+- [ ] Retrieval tested: correct memories/documents surface for test queries
+- [ ] Negative testing: model correctly refuses out-of-scope requests

--- a/.claude/skills/context-engineering/references/memory-and-sessions.md
+++ b/.claude/skills/context-engineering/references/memory-and-sessions.md
@@ -1,0 +1,244 @@
+# Memory and Sessions
+
+This reference covers how to use memory effectively in agent-assisted development: the three memory types, how to extract and consolidate knowledge, provenance tracking, and practical patterns for OAK CI's memory tools.
+
+---
+
+## Memory Types
+
+### Episodic Memory (What Happened)
+
+Records of specific events, experiences, and outcomes. Time-stamped, contextual, narrative — answers "what happened last time?"
+
+- Tied to a specific moment and context
+- Includes cause, effect, and resolution
+- Most valuable when recent; decays in relevance over time
+- Forms raw material for semantic memory through consolidation
+
+**Examples:**
+- "Refactoring broke auth tests — circular imports between `auth_service.py` and `user_service.py`"
+- "Customer API returned 429s after batch size increased to 100 — dropped to 50"
+
+**OAK CI mapping:** Observations with type `bug_fix` or `gotcha`
+
+### Procedural Memory (How To Do Things)
+
+Skills, workflows, and step-by-step processes. Relatively stable — changes slowly as best practices evolve.
+
+- Describes a sequence of actions to achieve a goal
+- Codified in documentation, runbooks, or constitutions
+- Most valuable when accurate and current
+
+**Examples:**
+- "To add a new API endpoint: create route, add service method, write tests, update docs"
+- "To add a new OAK feature: create manifest.yaml, implement RFC, add commands, register in feature service"
+
+**OAK CI mapping:** Constitutions (`oak/constitution.md`), skill files, golden paths. Procedural memory lives in structured documents rather than individual observations.
+
+### Semantic Memory (Facts and Concepts)
+
+General knowledge about the domain, codebase, or system. Context-independent — true regardless of when or how it was learned.
+
+- Factual, declarative knowledge
+- Stable until the underlying reality changes
+- Provides context without requiring the full history
+
+**Examples:**
+- "This project uses PostgreSQL 15 with read replicas for reporting queries"
+- "We chose event sourcing for the order system to support audit requirements"
+
+**OAK CI mapping:** Observations with type `discovery`, `decision`, or `trade_off`
+
+### Memory Type Selection Guide
+
+| You want to remember... | Memory Type | OAK CI Type |
+|---|---|---|
+| A bug you fixed and why | Episodic | `bug_fix` |
+| A non-obvious behavior | Episodic | `gotcha` |
+| How to deploy the app | Procedural | Constitution/Skill |
+| An architectural decision | Semantic | `decision` |
+| A pattern you discovered | Semantic | `discovery` |
+| A trade-off you accepted | Semantic | `trade_off` |
+
+**Rule of thumb:** If it happened once and the specifics matter, it is episodic. If it is always true (until something changes), it is semantic. If it describes how to do something, it is procedural.
+
+---
+
+## Memory Extraction Pipeline
+
+Raw experience becomes useful memory through four stages: capture, classify, consolidate, retrieve.
+
+### 1. Capture (During Work)
+
+Record observations as they happen — context and detail fade quickly. Capture surprising behavior, root causes (not symptoms), decisions with rationale, and codebase discoveries.
+
+```bash
+# Good — specific, includes file path and root cause
+oak ci remember "Auth middleware silently swallows ConnectionError — returns 200 instead of 503. Bare except on line 47" --type gotcha --context src/middleware/auth.py
+
+# Bad — vague, no actionable detail
+oak ci remember "Auth has a bug" --type gotcha
+```
+
+**Every observation should include:** what happened, where it applies (file paths), and why it matters.
+
+### 2. Classify
+
+Assign a type based on what kind of knowledge the observation represents.
+
+| Observation is about... | Classify as |
+|---|---|
+| Something that broke and how you fixed it | `bug_fix` |
+| A non-obvious behavior that could trip someone up | `gotcha` |
+| A fact about the system or domain | `discovery` |
+| A choice you made and why | `decision` |
+| A compromise with known downsides | `trade_off` |
+
+### 3. Consolidate
+
+Individual episodic memories should consolidate into semantic knowledge over time — specific events become general understanding.
+
+**Example:** Three separate gotchas about parallel test failures (shared session state, shared mock gateway, shared email queue) consolidate into one decision: "Integration tests using shared external state must use the `isolated_services` fixture."
+
+```bash
+# Create the consolidated observation
+oak ci remember "Integration tests with shared external state must use isolated_services fixture" --type decision --context tests/conftest.py
+
+# Resolve the observations it replaces
+oak ci resolve <uuid-1> --status superseded
+oak ci resolve <uuid-2> --status superseded
+```
+
+**When to consolidate:** Three or more observations about the same topic, or a pattern has emerged from individual incidents.
+
+### 4. Retrieve
+
+Pull relevant memories when starting new work.
+
+```bash
+# Automatic context assembly — curated code + memories based on task and files
+oak ci context "refactoring the auth service" -f src/services/auth.py
+
+# Targeted search by type
+oak ci search "auth import issues" --type memory
+oak ci search "rate limiting" --type all
+```
+
+---
+
+## Provenance Tracking
+
+Every memory should answer: who learned this, when, and from what evidence?
+
+### Why Provenance Matters
+
+Stale memories are worse than no memories — they actively mislead. An observation saying "the users table has no index on email" causes agents to work around a problem that was fixed last week. Provenance (when recorded, what code referenced) lets you detect and resolve staleness.
+
+### OAK CI Provenance Fields
+
+| Field | What it records |
+|---|---|
+| `session_id` | Which session created the observation |
+| `created_at_epoch` | When it was created (Unix timestamp) |
+| `context` | File path or additional context linking to code |
+| `session_origin_type` | Planning, investigation, or implementation |
+| `resolved_by_session_id` | Which session marked it resolved |
+| `resolved_at` | When it was resolved |
+
+### Provenance Best Practices
+
+**Include file paths in the context field.** Ties memory to code, enabling staleness detection when code changes.
+
+```bash
+# Good — tied to specific code
+oak ci remember "Rate limiter uses fixed window, not sliding — burst at window boundaries" --type discovery --context src/middleware/rate_limiter.py
+
+# Weak — floating, hard to verify later
+oak ci remember "Rate limiter has a burst problem" --type discovery
+```
+
+**Include error messages and specific details** for searchability. **Record session type** — implementation observations (tested and verified) carry more weight than planning observations (potentially speculative).
+
+---
+
+## Memory-as-a-Tool Pattern
+
+Instead of holding everything in the context window, treat memory as an external tool queried on demand.
+
+### The Workflow
+
+```
+Agent receives task -> searches memory -> gets relevant results -> uses in current work -> stores new learnings -> future sessions benefit
+```
+
+**Benefits:** Context window stays focused on the current task. Memory accumulates across sessions. Each retrieval is targeted. Knowledge persists beyond session boundaries and is shared across agents.
+
+### OAK CI Commands
+
+**Store** during work:
+```bash
+oak ci remember "Billing API rate limits at 100 req/min — returns 429 with Retry-After" --type discovery
+```
+
+**Retrieve** when starting work:
+```bash
+oak ci search "billing API rate limits" --type memory
+oak ci context "refactoring the auth service" -f src/services/auth.py
+```
+
+**Resolve** when memory becomes stale:
+```bash
+oak ci resolve <uuid> --reason "Refactored to eliminate circular dependency"
+oak ci resolve <uuid> --status superseded --reason "Replaced by event-driven architecture"
+```
+
+---
+
+## Session Memory Patterns
+
+### Session Summaries
+
+At session end, generate a summary: what was accomplished, what was learned, what remains. OAK CI stores these as `session_summary` observations, creating episodic memories for future sessions.
+
+**A good session summary includes:**
+- Tasks completed (with file paths)
+- Decisions made and their rationale
+- Open questions or unfinished work
+- Observations stored during the session
+
+### Cross-Session Context
+
+Retrieve relevant context from past sessions when starting new work:
+
+```bash
+oak ci context "continuing the auth refactor" -f src/services/auth.py -f src/services/user.py
+```
+
+This returns relevant memories (including past session summaries) alongside related code, providing continuity without full conversation history.
+
+### Memory Decay and Maintenance
+
+Not all memories stay relevant. Active maintenance prevents memory rot. Resolve observations when: the referenced code was refactored or deleted, the decision was reversed, the gotcha was fixed, or newer observations cover the same ground better.
+
+| Situation | Action |
+|---|---|
+| Bug was fixed | Resolve the `bug_fix` observation |
+| Gotcha no longer applies | Resolve the `gotcha` observation |
+| Decision was reversed | Mark `superseded`, create new decision |
+| Observations overlap | Consolidate into one, resolve the rest |
+| Code was deleted | Resolve related observations |
+
+---
+
+## Common Memory Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|---|---|---|
+| Storing everything | Bloat, poor retrieval — important observations buried in noise | Be selective: only store what would help a future session |
+| Vague observations | "Auth was broken" — useless for retrieval, no actionable guidance | Include specifics: error messages, file paths, root cause |
+| Never resolving | Stale memories mislead sessions into working around fixed problems | Resolve observations after addressing the issue |
+| No context field | Memory disconnected from code, cannot validate against current state | Always include file paths or module names |
+| Duplicate observations | Same insight stored multiple times degrades precision | Search before storing; consolidate duplicates |
+| Session-only memory | Knowledge lost when session ends | Use persistent memory for learnings worth keeping |
+| Over-consolidation | Premature generalization loses nuance from specific incidents | Wait for three or more instances before generalizing |
+| No provenance | Cannot assess validity; no way to trace back to evidence | Include file paths, timestamps, and specific details |

--- a/.claude/skills/context-engineering/references/prompt-foundations.md
+++ b/.claude/skills/context-engineering/references/prompt-foundations.md
@@ -1,0 +1,322 @@
+# Prompt Engineering Foundations
+
+Eight core techniques for writing effective prompts. Each section covers: what it is, when to use it, how to apply it, a concrete example, and common mistakes.
+
+---
+
+## 1. Be Clear and Direct
+
+Specificity eliminates ambiguity. Tell the model exactly what you want — format, length, style, and constraints.
+
+**How to apply:**
+- State the task, format, and constraints up front
+- Use imperative verbs: "List", "Analyze", "Write", "Compare"
+- Specify exclusions when they matter
+- Define success criteria
+
+**Example — bad vs good:**
+
+```
+Bad:  Review this code.
+
+Good: Review this Python function for:
+      1. Security vulnerabilities (injection, XSS)
+      2. Performance issues (N+1 queries, unnecessary allocations)
+      3. Correctness bugs (off-by-one, null handling)
+
+      For each issue: line number, severity (critical/warning/info),
+      and corrected code. If none found, say "None found."
+```
+
+**Mistakes:** Assuming the model infers format preferences. Using vague qualifiers ("good", "comprehensive") without defining them. Omitting constraints then being surprised by the output shape.
+
+---
+
+## 2. Use Examples (Multishot Prompting)
+
+Provide 3-5 input-output examples demonstrating the pattern you want. Examples are the most reliable way to specify format, tone, and edge case handling.
+
+**How to apply:**
+- 3-5 examples minimum (one or two won't establish a pattern)
+- Vary them: happy path, edge cases, boundary conditions, negative cases
+- Show exact input-output structure
+- Order simple to complex
+
+**Example:**
+
+```xml
+Classify each customer message into exactly one category.
+
+<examples>
+<example>
+<input>I can't log in even with the right password</input>
+<output>category: authentication | priority: high</output>
+</example>
+<example>
+<input>How much does the enterprise plan cost?</input>
+<output>category: billing | priority: low</output>
+</example>
+<example>
+<input>Your product crashed during my presentation!!!</input>
+<output>category: bug-report | priority: critical</output>
+</example>
+<example>
+<input></input>
+<output>category: invalid | priority: none</output>
+</example>
+</examples>
+
+Now classify: <input>{{MESSAGE}}</input>
+```
+
+The last example teaches the model how to handle malformed input rather than leaving it to guess.
+
+**Mistakes:** Only showing happy-path examples. Examples too similar to each other. Inconsistent formatting across examples (the model mirrors inconsistency).
+
+---
+
+## 3. Chain of Thought (CoT)
+
+Instruct the model to reason step by step before answering. Dramatically improves accuracy on logic, math, and multi-step analysis.
+
+**Three levels:**
+
+**Basic** — add "Think step by step." Simple, effective for straightforward reasoning.
+
+**Guided** — provide numbered steps when the reasoning process matters:
+```
+Determine if this function has a bug:
+1. Identify what it should do from name and docstring
+2. Trace logic with a normal input
+3. Trace with edge cases (empty, null, boundary)
+4. Compare actual vs expected behavior
+5. Conclude: bug or no bug, with evidence
+```
+
+**Structured** — wrap reasoning in tags to separate thinking from output:
+```xml
+Analyze whether this migration is safe for production.
+
+Work through your analysis inside <reasoning> tags, then give your
+verdict inside <verdict> tags. Consider: table locks, reversibility,
+data backfill volume, partial failure scenarios.
+```
+
+| Level | Use when |
+|---|---|
+| Basic | Simple math, single-step deductions |
+| Guided | Multi-step debugging, analysis where process matters |
+| Structured | Complex decisions, when downstream systems consume the reasoning |
+
+**Mistakes:** Using CoT for simple factual lookups (adds latency, no accuracy gain). Over-constraining the thinking format. Asking for "just the answer" on hard problems.
+
+---
+
+## 4. Use XML Tags for Structure
+
+Claude treats XML tags as first-class structural elements — the most reliable way to separate context, instructions, examples, and output format.
+
+**When to use:** Any prompt with more than one logical section, when mixing data with instructions, when specifying output format.
+
+**Example:**
+```xml
+<context>
+Debugging a failing test suite. Project: Python 3.12, pytest.
+</context>
+
+<test_output>
+FAILED test_auth.py::test_login_redirect - expected 302, got 200
+FAILED test_auth.py::test_expired_token - connection pool exhausted
+</test_output>
+
+<instructions>
+For each failure: identify root cause, determine if related, suggest fix.
+</instructions>
+
+<output_format>
+## [test name]
+**Root cause:** [one sentence]
+**Related:** [yes/no and why]
+**Fix:** [code block]
+</output_format>
+```
+
+**Nesting** for hierarchy (two levels is usually sufficient):
+```xml
+<documents>
+  <document id="1" title="API Spec">...content...</document>
+  <document id="2" title="Error Logs">...content...</document>
+</documents>
+```
+
+**Mistakes:** Generic tag names (`<data>`) instead of specific ones (`<error_log>`). Over-nesting beyond two levels. Mixing XML tags with markdown headers for the same purpose.
+
+---
+
+## 5. Give Claude a Role (System Prompts)
+
+The system prompt establishes persistent behavioral context — role, constraints, and output conventions that frame every response.
+
+**How to apply:**
+- Define role, expertise, and boundaries
+- Set the right altitude: specific enough to be useful, general enough for varied inputs
+- Include what to do when uncertain
+
+**Example — bad vs good:**
+
+```
+Bad:  You are a helpful coding assistant. Be thorough and accurate.
+```
+"Helpful" and "thorough" are not actionable — they contain no specific guidance.
+
+```xml
+Good:
+<role>
+Senior backend engineer. Python + PostgreSQL.
+Production system handling financial transactions.
+</role>
+
+<constraints>
+- Never sacrifice data consistency for performance
+- Flag non-idempotent operations
+- When unsure, say "I'm not confident because..." rather than guessing
+</constraints>
+
+<output_conventions>
+- Python type hints in all code examples
+- Include error handling (no happy-path-only code)
+- Reference specific line numbers when reviewing
+</output_conventions>
+```
+
+**Mistakes:** System prompt so long it dilutes the important parts. Only negative instructions ("don't do X") without positive guidance. Role too narrow, causing refusals on legitimate requests.
+
+---
+
+## 6. Chain Complex Prompts
+
+Break complex tasks into sequential steps where output of step N feeds step N+1. Better results than asking for everything at once.
+
+**When to use:** Tasks with distinct phases (research, analyze, synthesize). When quality at each step matters. When different steps need different instructions.
+
+**Example pipeline:**
+```
+Step 1 (Extract):  "Extract all function signatures and docstrings."
+Step 2 (Analyze):  "For each function, identify missing error handling,
+                    unused params, unclear naming. Rate severity."
+Step 3 (Synthesize): "Group by severity. Write corrected code for
+                      critical/warning issues. Summarize in a table."
+```
+
+**Gate outputs between steps** — validate before passing forward:
+```python
+extracted = call_model(step_1_prompt, document)
+
+# Gate: verify extraction produced results
+if not extracted.functions:
+    raise ValueError("Extraction empty — check input format")
+
+analysis = call_model(step_2_prompt, extracted)
+```
+
+**Mistakes:** Passing too much context between steps (carry only what the next step needs). Not validating intermediates. Steps too granular (each should do meaningful work).
+
+---
+
+## 7. Long Context Window Tips
+
+Position and organization of information in the context window significantly affects output quality. The "lost in the middle" effect means information buried in the center of very long contexts gets less attention.
+
+**Key techniques:**
+
+**Front-load and repeat critical instructions:**
+```xml
+<instructions>
+<!-- FIRST: anchor behavior -->
+Find all security vulnerabilities. Focus on injection, auth bypass, data exposure.
+</instructions>
+
+<codebase>
+...thousands of lines...
+</codebase>
+
+<reminder>
+<!-- LAST: reinforce -->
+Focus only on security vulnerabilities.
+Format: file, line, type, severity, fix.
+</reminder>
+```
+
+**Tag-delineate sections** when including multiple documents:
+```xml
+<documents>
+  <document title="Auth Module" path="src/auth.py">...code...</document>
+  <document title="Schema" path="schema.sql">...schema...</document>
+</documents>
+```
+
+**Include retrieval hints** for very long contexts: "Find the users table in the Schema document and check for a unique constraint on email."
+
+**Order by relevance:** most relevant documents first. For bug analysis: error/stack trace, then source file, then config, then tests, then docs.
+
+**Mistakes:** Dumping context without structure. Critical instructions only in the middle. Including irrelevant context "just in case" (dilutes attention).
+
+---
+
+## 8. Extended Thinking
+
+Extended thinking allocates dedicated tokens for the model to reason internally before producing a visible response. Unlike CoT, this happens in a separate, larger thinking space and can use significantly more tokens.
+
+**When to use:**
+- Complex math or proofs
+- Multi-file code analysis with component interactions
+- Architecture decisions with many tradeoffs
+- Debugging where root cause is non-obvious
+
+**When NOT to use:** Simple factual questions, straightforward code generation, tasks where speed matters more than depth.
+
+**How to apply:**
+
+Set thinking budget based on complexity: small for simple debugging, large for architecture review or multi-step planning.
+
+Let the model reason freely — don't constrain thinking format:
+```
+Good: "Analyze this distributed system for consistency issues.
+       Think deeply about edge cases before responding."
+
+Bad:  "In your thinking, first list all components, then draw
+       arrows between them, then..."
+```
+
+Specify what to *produce*, not how to *think*. Combine with structured output:
+```xml
+<task>
+Review this migration plan. Consider data integrity, rollback safety,
+and performance impact on a 50M-row table.
+</task>
+
+<output_format>
+1. GO / NO-GO recommendation
+2. Risk summary (one paragraph)
+3. Required changes before deploy (bulleted list)
+</output_format>
+```
+
+**Mistakes:** Enabling for every prompt (wastes tokens on simple tasks). Controlling the thinking format. Using thinking as substitute for providing good context.
+
+---
+
+## Anti-Patterns Reference
+
+| Anti-Pattern | Why It Fails | Fix |
+|---|---|---|
+| "Be helpful" | Too vague, no actionable guidance | Specify exact behavior, constraints, output format |
+| Contradictory instructions | Model picks one unpredictably | Resolve conflicts; prioritize with "IMPORTANT" |
+| Wall of text prompt | Key info buried, position bias | Structure with XML; front-load critical info |
+| No examples | Model guesses output format | Add 3-5 diverse multishot examples |
+| "Do everything at once" | Exceeds single-prompt capacity | Chain into sequential steps with gates |
+| Overly rigid templates | Brittle to edge cases | Define principles and show examples instead |
+| "Don't do X" (only negatives) | Model attention anchors on X | State what TO do instead |
+| Expecting one-shot perfection | Unrealistic for complex tasks | Iterate: test varied inputs, refine on failures |
+| Kitchen-sink system prompt | Dilutes important instructions | Keep focused: role, constraints, output conventions |
+| No output validation | Hallucinations and drift undetected | Validate between chained steps |

--- a/.claude/skills/context-engineering/references/system-prompt-design.md
+++ b/.claude/skills/context-engineering/references/system-prompt-design.md
@@ -1,0 +1,237 @@
+# System Prompt Design
+
+System prompts define who the model is, what it should do, and how it should behave. This reference covers effective system prompt anatomy, writing instructions at the right abstraction level, Claude-specific patterns, and annotated templates.
+
+---
+
+## System Prompt Anatomy
+
+Every effective system prompt has five components, in this order. Ordering matters — models give more weight to content that appears earlier.
+
+### 1. Role and Identity
+
+One or two sentences establishing domain expertise. Sets tone, vocabulary, and decision-making framework.
+
+```
+You are a senior backend engineer specializing in distributed systems.
+```
+
+Be specific enough to shape behavior, broad enough to handle varied inputs. Avoid character fiction ("Dr. Sarah Chen, known for dry wit") — it dilutes technical focus. Avoid generics ("You are a helpful assistant") — it changes nothing.
+
+### 2. Core Constraints
+
+Hard rules the model must always follow. Put these BEFORE task instructions — models respect early constraints more reliably. Use RFC 2119 language (MUST, MUST NOT, SHOULD, MAY) for clarity.
+
+```xml
+<constraints>
+- You MUST NOT modify database schema without explicit approval
+- You MUST cite specific file and line numbers when identifying issues
+- You SHOULD prefer backward-compatible solutions
+- When uncertain, ask for clarification rather than guessing
+</constraints>
+```
+
+The last line is critical — every system prompt should define what the model does when unsure. Without it, the model either guesses (risky) or refuses (unhelpful).
+
+### 3. Task Instructions
+
+What the model should do. Write at the right "altitude" — principles over procedures (see the Altitude Scale below).
+
+```xml
+<instructions>
+When reviewing code, focus on correctness and security over style.
+Flag potential issues but do not rewrite working code for aesthetic reasons.
+When multiple approaches exist, explain the tradeoffs and recommend one.
+</instructions>
+```
+
+Good task instructions answer: What is the primary objective? What gets prioritized when objectives conflict? What does "done" look like?
+
+### 4. Output Format
+
+Be explicit — the model won't consistently infer format preferences.
+
+```xml
+<output_format>
+Respond with a JSON object:
+{
+  "summary": "One-sentence assessment",
+  "issues": [{"severity": "critical|warning|info", "file": "path", "line": 42, "description": "...", "suggestion": "..."}],
+  "overall_rating": "approve | request-changes | needs-discussion"
+}
+</output_format>
+```
+
+If you want markdown, say so. If you want JSON, provide the schema. Ambiguity here is the most common source of format drift.
+
+### 5. Canonical Examples
+
+Two to three input-output pairs demonstrating ideal behavior. Examples anchor behavior more reliably than instructions alone. Show range (positive and negative cases) and edge cases.
+
+```xml
+<example>
+<input>
+def get_user(id):
+    query = f"SELECT * FROM users WHERE id = {id}"
+    return db.execute(query)
+</input>
+<output>
+**Critical: SQL Injection** — line 2 uses f-string with user input.
+Fix: `db.execute("SELECT * FROM users WHERE id = ?", [id])`
+</output>
+</example>
+```
+
+---
+
+## The Altitude Scale
+
+The most common system prompt mistake is writing instructions at the wrong abstraction level.
+
+### Level 1: Ground Level (Too Specific)
+
+```
+Always use 4-space indentation. Variable names must be camelCase.
+Functions must not exceed 20 lines.
+```
+
+Brittle. Doesn't adapt to context. What happens when the codebase uses tabs?
+
+### Level 2: Cruising Altitude (Right Level)
+
+```
+Follow the project's established conventions. Match surrounding
+code style. Prefer clarity over cleverness.
+```
+
+Principled, adaptable. Handles novel situations because it has principles, not just rules.
+
+### Level 3: Stratosphere (Too Vague)
+
+```
+Write good code. Be helpful. Follow best practices.
+```
+
+No actionable guidance. The model falls back to generic behavior.
+
+### Finding Your Altitude
+
+| Domain | Too Low | Right Altitude | Too High |
+|---|---|---|---|
+| Code Review | "Flag if cyclomatic complexity > 10" | "Flag functions hard to understand at a glance" | "Review the code" |
+| Writing | "Sentences must be 12-15 words" | "Write concisely. Prefer short sentences. Cut filler." | "Write well" |
+| Data Analysis | "Use pandas groupby then merge" | "Use efficient operations. Profile before optimizing." | "Analyze the data" |
+| Security Audit | "Check for CVE-2024-1234" | "Identify injection points and trust boundaries" | "Find vulnerabilities" |
+
+**The test:** If your instruction applies regardless of language, framework, or codebase, it's the right altitude.
+
+---
+
+## Claude-Specific Patterns
+
+### XML Tag Conventions
+
+Claude has strong native understanding of XML structure:
+
+- `<context>`, `<instructions>`, `<constraints>`, `<examples>` for top-level sections
+- Nesting up to 2-3 levels: `<examples><example><input>...</input><output>...</output></example></examples>`
+- Attributes for metadata: `<document id="1" title="API Spec" path="src/api.py">`
+- Descriptive tag names — `<error_log>` over `<data>`, `<user_request>` over `<input>`
+- No `<system>` wrapper needed — Claude already knows it's reading a system prompt
+
+### Extended Thinking Integration
+
+Guide the model toward deeper reasoning without constraining its process. Say "Think deeply about edge cases before responding" (good) rather than "First list all components, then draw arrows, then rate each on a 1-5 scale" (bad). Specify what to produce, not how to think.
+
+### Prefilling
+
+Start the assistant's response to anchor output format:
+
+```
+Assistant: {"analysis":
+```
+
+Useful for ensuring JSON output, anchoring structure, or preventing preamble ("Sure! Here's my analysis..."). Use prefilling for format, not for constraining reasoning.
+
+---
+
+## Annotated Templates
+
+### Code Review Agent
+
+```xml
+You are a senior software engineer performing code review.
+
+<constraints>
+- Focus on correctness, security, and maintainability
+- Do NOT rewrite working code for style preferences alone
+- Flag potential bugs with severity: critical, warning, info
+- If uncertain whether something is a bug, say so explicitly
+- MUST NOT approve code with known security vulnerabilities
+</constraints>
+
+<instructions>
+Review the provided code changes. For each issue:
+1. Identify the file and line
+2. Describe the issue and why it matters
+3. Suggest a fix
+
+After reviewing, provide a summary assessment.
+If no issues are found, say so — do not fabricate issues.
+</instructions>
+```
+
+Constraints before instructions, "do not fabricate" prevents false positives, severity levels in constraints keep output consistent.
+
+### Research Assistant
+
+```xml
+You are a research assistant analyzing documents and synthesizing findings.
+
+<constraints>
+- Cite sources with specific quotes or page references
+- Distinguish facts in documents from your inferences
+- If asked about something not in the documents, say so clearly
+- MUST NOT fabricate citations or references
+</constraints>
+
+<instructions>
+Analyze provided documents: identify themes, note contradictions between
+sources, synthesize findings. Use <finding> tags with source attribution.
+</instructions>
+
+<output_format>
+<finding source="Document Title, p. X">
+[Insight with direct quote or specific reference]
+</finding>
+</output_format>
+```
+
+MUST NOT on fabricated citations addresses the highest-risk failure mode. Distinguishing facts from inferences prevents the model from presenting reasoning as source material.
+
+### Data Analysis Agent
+
+```xml
+You are a data analyst working with structured datasets.
+
+<constraints>
+- Show methodology before results
+- Validate data quality before analysis (nulls, duplicates, outliers)
+- State assumptions explicitly
+- Do not over-interpret small samples (note when n < 30)
+</constraints>
+
+<instructions>
+For each analysis: understand the question, examine data quality,
+choose and explain the method, present findings with caveats.
+Prefer tables over prose for numerical results.
+</instructions>
+```
+
+Methodology-before-results prevents jumping to conclusions. Concrete threshold (n < 30) instead of vague "be careful."
+
+---
+
+## Cross-Reference
+
+See also: The `/project-governance` skill for creating and maintaining project constitutions and agent rules files — these are system prompts implemented as version-controlled documents.

--- a/.claude/skills/project-governance/SKILL.md
+++ b/.claude/skills/project-governance/SKILL.md
@@ -68,6 +68,7 @@ oak rules detect-existing      # Discover all configured agent instruction files
 - **Creating CLAUDE.md, AGENTS.md, or .cursorrules** for a new project
 - **Proposing a new feature** that needs team review (RFC)
 - **Making architectural decisions** that should be documented (ADR)
+- **Learning context engineering theory** behind effective rule writing -- see `/context-engineering` for the altitude concept, canonical examples, and structured context patterns
 - **Reviewing an RFC** for completeness and technical soundness
 
 ## Constitution Structure

--- a/.codex/skills/codebase-intelligence/SKILL.md
+++ b/.codex/skills/codebase-intelligence/SKILL.md
@@ -124,7 +124,7 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "YOUR QUERY HERE"
 | Table | Purpose | Key Columns |
 |-------|---------|-------------|
 | `memory_observations` | Extracted memories/learnings | `observation`, `memory_type`, `status`, `context`, `tags`, `importance`, `session_origin_type` |
-| `sessions` | Coding sessions (launch to exit) | `id`, `agent`, `status`, `summary`, `title`, `started_at`, `created_at_epoch` |
+| `sessions` | Coding sessions (launch to exit) | `id`, `agent`, `status`, `summary`, `title`, `title_manually_edited`, `started_at`, `created_at_epoch` |
 | `prompt_batches` | User prompts within sessions | `session_id`, `user_prompt`, `classification`, `response_summary` |
 | `activities` | Raw tool executions | `session_id`, `tool_name`, `file_path`, `success`, `error_message` |
 | `agent_runs` | CI agent executions | `agent_name`, `task`, `status`, `result`, `cost_usd`, `turns_used` |

--- a/.codex/skills/codebase-intelligence/SKILL.md
+++ b/.codex/skills/codebase-intelligence/SKILL.md
@@ -130,7 +130,7 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "YOUR QUERY HERE"
 | `agent_runs` | CI agent executions | `agent_name`, `task`, `status`, `result`, `cost_usd`, `turns_used` |
 | `session_link_events` | Session linking analytics | `session_id`, `event_type`, `old_parent_id`, `new_parent_id` |
 | `session_relationships` | Semantic session relationships | `session_a_id`, `session_b_id`, `relationship_type`, `similarity_score` |
-| `agent_schedules` | Cron scheduling state | `task_name`, `cron_expression`, `enabled`, `last_run_at`, `next_run_at` |
+| `agent_schedules` | Cron scheduling state | `task_name`, `cron_expression`, `enabled`, `additional_prompt`, `last_run_at`, `next_run_at` |
 | `resolution_events` | Cross-machine resolution propagation | `observation_id`, `action`, `source_machine_id`, `applied`, `content_hash` |
 <!-- END GENERATED CORE TABLES -->
 

--- a/.codex/skills/codebase-intelligence/references/schema.md
+++ b/.codex/skills/codebase-intelligence/references/schema.md
@@ -2,7 +2,7 @@
 
 Complete DDL for the Oak CI SQLite database at `.oak/ci/activities.db`.
 
-Current schema version: **4**
+Current schema version: **6**
 
 ## memory_observations
 
@@ -53,11 +53,14 @@ CREATE TABLE IF NOT EXISTS sessions (
     processed BOOLEAN DEFAULT FALSE,  -- Has background processor handled this?
     summary TEXT,  -- LLM-generated session summary
     title TEXT,  -- LLM-generated short session title (10-20 words)
+    title_manually_edited BOOLEAN DEFAULT FALSE,  -- Protect manual edits from LLM overwrite
     created_at_epoch INTEGER NOT NULL,
     parent_session_id TEXT,  -- Session this was derived from
     parent_session_reason TEXT,  -- Why linked: 'clear', 'compact', 'inferred'
     source_machine_id TEXT,  -- Machine that originated this record
-    transcript_path TEXT  -- Path to session transcript file for recovery
+    transcript_path TEXT,  -- Path to session transcript file for recovery
+    summary_updated_at INTEGER,  -- Epoch when summary was last generated/updated
+    summary_embedded INTEGER DEFAULT 0  -- Has summary been indexed in ChromaDB?
 );
 ```
 

--- a/.codex/skills/codebase-intelligence/references/schema.md
+++ b/.codex/skills/codebase-intelligence/references/schema.md
@@ -2,7 +2,7 @@
 
 Complete DDL for the Oak CI SQLite database at `.oak/ci/activities.db`.
 
-Current schema version: **3**
+Current schema version: **4**
 
 ## memory_observations
 
@@ -228,6 +228,7 @@ CREATE TABLE IF NOT EXISTS agent_schedules (
     cron_expression TEXT,           -- Cron expression (e.g., '0 0 * * MON')
     description TEXT,               -- Human-readable schedule description
     trigger_type TEXT DEFAULT 'cron', -- 'cron' or 'manual' (future: 'git_commit', 'file_change')
+    additional_prompt TEXT,          -- Persistent assignment prepended to task on each run
 
     -- Runtime state
     last_run_at TEXT,

--- a/.codex/skills/context-engineering/SKILL.md
+++ b/.codex/skills/context-engineering/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: context-engineering
+description: >-
+  Design effective prompts and optimize context for AI models and agents.
+  Covers prompt engineering foundations (clarity, examples, chain of thought,
+  XML structure), the four context engineering strategies (Write, Select,
+  Compress, Isolate), agent memory and session patterns, and before/after
+  examples showing measurable improvement. Use when writing system prompts,
+  designing agent workflows, optimizing context windows, building prompt
+  templates, structuring few-shot examples, reducing context rot, or
+  improving AI output quality.
+allowed-tools: Read
+user-invocable: true
+---
+
+# Context Engineering
+
+Design effective prompts and optimize the full context window for AI models and agents to produce consistently high-quality output.
+
+## Quick Start
+
+### Recipe 1: Improve a vague prompt
+
+**Before:** `Review this code and give feedback.`
+
+**After:**
+```xml
+<task>Review the provided code for correctness, performance, and maintainability.</task>
+<output-format>
+For each issue: file/line, severity (critical|warning|suggestion), problem (one sentence), fix (concrete code change).
+If no issues, state "No issues found" and list one strength.
+</output-format>
+<code>{{code_to_review}}</code>
+```
+
+**Why it works:** Specifies evaluation criteria, defines output structure, separates instructions from data with XML tags.
+
+### Recipe 2: Design a system prompt
+
+Use the **altitude concept** -- not so high it's useless ("be helpful"), not so low it's brittle ("always use 4 spaces").
+
+1. **Define the role** in one sentence: what the agent IS and IS NOT
+2. **Set altitude** -- right level: "Follow the project's existing naming conventions. When none exists, prefer descriptive names over short ones."
+3. **Add constraints** using RFC 2119 language (MUST, SHOULD, MAY)
+4. **Include 1-2 canonical examples** of ideal output
+5. **Define non-goals** to prevent scope creep
+
+See `references/system-prompt-design.md` for full anatomy and templates.
+
+### Recipe 3: Structure agent context with the 4 strategies
+
+When your agent produces inconsistent or degraded output, apply the four strategies:
+
+| Strategy | Action | Example |
+|----------|--------|---------|
+| **Write** | Craft persistent instructions | System prompt with altitude-appropriate rules |
+| **Select** | Choose what enters context | Use `oak_search` to retrieve only relevant code |
+| **Compress** | Reduce tokens, preserve signal | Summarize prior conversation turns, delegate to sub-agents |
+| **Isolate** | Move information out of context | Store reference docs externally, load just-in-time |
+
+```
+1. Start with Write: define a clear system prompt
+2. Apply Select: give the agent only the tools and context it needs
+3. Add Compress: implement compaction for long sessions
+4. Use Isolate: move large reference material behind retrieval
+```
+
+See `references/context-engineering-framework.md` for the full framework.
+
+## The Evolution: Prompt to Context Engineering
+
+| Level | Focus | Scope | Key Insight |
+|-------|-------|-------|-------------|
+| **Basic Prompting** | The question you type | Single user message | Clarity matters |
+| **Prompt Engineering** | Crafting effective prompts | Prompt + examples + structure | Technique amplifies quality |
+| **Context Engineering** | Everything the model sees | System prompt + tools + memory + retrieved docs + conversation history | The context window IS the product |
+
+Context engineering manages **everything** the model sees -- system prompt, tools, retrieved documents, conversation history, and memory. Every token either helps or hurts. The entire context window is a design surface.
+
+## Prompt Engineering Foundations
+
+These eight techniques form the foundation. Master them before moving to context engineering.
+
+| # | Technique | When to Use | Key Rule |
+|---|-----------|-------------|----------|
+| 1 | **Be clear and direct** | Always -- this is the baseline | State exactly what you want; remove ambiguity |
+| 2 | **Use examples (multishot)** | Output format matters, or the task is nuanced | Show 2-3 examples of ideal input/output pairs |
+| 3 | **Chain of thought** | Reasoning, math, multi-step logic | Ask the model to think step-by-step before answering |
+| 4 | **Use XML tags** | Separating instructions from data, structured output | Wrap distinct sections in descriptive tags like `<context>`, `<instructions>` |
+| 5 | **Give Claude a role** | Specialized tasks needing domain expertise | Set the role in the system prompt, not the user message |
+| 6 | **Chain complex prompts** | Multi-step workflows, pipelines | Break into sequential steps; output of step N feeds step N+1 |
+| 7 | **Long context tips** | Large documents, many files | Put key instructions at top and bottom; use XML to delineate sections |
+| 8 | **Extended thinking** | Complex reasoning, planning, self-correction | Enable thinking to let the model plan before responding |
+
+**Combining techniques:** Most effective prompts use 3-5 techniques together. A code review prompt might combine clarity (#1), XML structure (#4), role (#5), and examples (#2).
+
+See `references/prompt-foundations.md` for detailed explanations, examples, and anti-patterns for each technique.
+
+## Context Engineering Framework (4 Strategies)
+
+### Write: Craft the persistent context
+
+The Write strategy covers everything you author in advance: system prompts, tool descriptions, and instruction files. This is the context you control completely.
+
+**The altitude concept** is the most important principle. Your instructions need to be at the right level of abstraction:
+
+| Altitude | Example | Problem |
+|----------|---------|---------|
+| Too high | "Write clean code" | No actionable guidance -- the agent fills in its own interpretation |
+| Too low | "Always use `Array.prototype.reduce` for aggregation" | Brittle -- breaks when context changes, prevents good judgment |
+| Right | "Prefer declarative patterns over imperative loops. Choose the array method that most clearly expresses intent." | Guides without constraining |
+
+**Canonical examples** are powerful -- a single well-chosen example communicates more than paragraphs of rules:
+
+```xml
+<system>
+You generate API documentation from source code.
+<example>
+<input>
+def calculate_tax(amount: float, rate: float = 0.08) -> float:
+    """Calculate sales tax for a given amount."""
+    return round(amount * rate, 2)
+</input>
+<output>
+### `calculate_tax(amount, rate=0.08)`
+Calculate sales tax for a given amount.
+- `amount` (float): The pre-tax amount
+- `rate` (float, optional): Tax rate as decimal. Default: 0.08
+- **Returns:** float -- Tax amount, rounded to 2 decimal places.
+</output>
+</example>
+</system>
+```
+
+**Project-level Write strategy:** Use the `/project-governance` skill to create a constitution (`oak/constitution.md`) and agent instruction files. Your constitution IS your project-level system prompt. The altitude concept applies directly: "write good code" is useless; "copy `src/features/auth/service.py` for new services" is actionable.
+
+See `references/context-engineering-framework.md` for the full Write strategy guide.
+
+### Select: Choose what enters the context window
+
+Select the right information to include; keep everything else out.
+
+**For tools:** Provide the **minimal viable toolset** (unused tools cause confusion), write **unambiguous descriptions** (the model uses these to decide when to call), and prefer **specific tools** over general-purpose ones.
+
+**For retrieved context:** Quality over quantity (3 relevant snippets beat 20 loose ones), recency matters, and always include source attribution (file paths, line numbers).
+
+**Anti-pattern -- context stuffing:**
+```
+# Bad: dumping everything "just in case"
+context = all_docs + all_code + all_history + all_memories
+# Good: selecting what's relevant
+context = search_relevant_code(task) + get_recent_decisions(task)
+```
+
+### Compress: Reduce tokens while preserving information
+
+Compress rather than truncate. Preserve signal while reducing cost.
+
+**Strategies:** Conversation summarization (replace old turns with structured summary), note-taking scratchpad (running notes vs. re-reading history), sub-agent delegation (offload research, return only findings), and tool result cleanup (extract then clear verbose output).
+
+**When to compress:** Context exceeds 50% capacity, agent forgets earlier instructions, responses repeat or lose focus, or tool results contain mostly irrelevant data.
+
+### Isolate: Move information out of the main context
+
+Store information externally and load just-in-time, rather than keeping it in context at all times.
+
+**Patterns:** Just-in-time retrieval (load docs only when needed), progressive disclosure (summary first, details on demand), hybrid context loading (rules in system prompt, reference material behind search), and memory-as-a-tool (store externally, retrieve on demand).
+
+**Progressive disclosure example:** Agent sees summary ("Auth uses JWT") -> needs details (retrieves auth docs) -> needs code (retrieves auth service file). Each step loads only what's needed.
+
+See `references/context-engineering-framework.md` for the complete framework with extended examples.
+
+## Agent Context Patterns
+
+### Sessions vs memory
+
+| Concept | Scope | Lifetime | Purpose |
+|---------|-------|----------|---------|
+| **Session** | Single conversation | Ephemeral | Working memory for the current task |
+| **Memory** | Cross-session | Persistent | Accumulated knowledge and learnings |
+
+The common mistake: keeping everything in the session instead of writing important things to persistent memory.
+
+### Context rot
+
+Output quality degrades as conversations grow longer due to: **dilution** (instructions buried under tool results), **position bias** (models attend more to beginning/end, losing middle), **contradiction accumulation**, and **working memory overflow**.
+
+**Signs:** Agent forgets earlier constraints, responses become generic/repetitive, re-asks answered questions, quality drops vs. early turns.
+
+**Mitigation:** Apply Compress (summarize and compact) and Isolate (move reference material behind retrieval). For long-running agents, implement periodic compaction checkpoints.
+
+### Memory types
+
+| Type | What It Stores | Example | OAK CI Tool |
+|------|---------------|---------|-------------|
+| **Episodic** | What happened | "Refactored auth module in session #42" | `oak_search --type memory` |
+| **Procedural** | How to do things | "To add a feature, copy the strategic_planning exemplar" | `oak_remember` with type `discovery` |
+| **Semantic** | Facts and concepts | "The API uses JWT tokens with 1-hour expiry" | `oak_remember` with type `discovery` |
+
+### Memory-as-a-tool pattern
+
+Store externally, retrieve on demand -- instead of accumulating in context:
+
+```
+1. Discover → oak_remember("auth tokens expire after 1 hour", type="discovery")
+2. Later   → oak_search("auth token expiry") retrieves just-in-time
+3. Stale   → oak_resolve_memory(id, status="resolved") cleans up
+```
+
+This implements both Compress (don't hold everything) and Isolate (retrieve when needed).
+
+### Compaction strategies
+
+| Strategy | How It Works | Best For |
+|----------|-------------|----------|
+| **Last-N** | Keep only the last N conversation turns | Simple, predictable token budget |
+| **Recursive summarization** | Summarize old turns, keep recent ones verbatim | Long conversations with important early context |
+| **Hybrid** | Summarize + keep pinned messages (system prompt, key decisions) | Complex agents with critical persistent instructions |
+
+See `references/agent-context-patterns.md` and `references/memory-and-sessions.md` for detailed patterns and implementation guidance.
+
+## CI Integration: Context Engineering in Practice
+
+OAK's Codebase Intelligence tools directly implement the four context engineering strategies:
+
+| Strategy | CI Tool | What It Does |
+|----------|---------|--------------|
+| **Write** | `oak_remember` / `oak ci remember` | Persist learnings, decisions, and gotchas to long-term memory |
+| **Select** | `oak_search` / `oak ci search` | Retrieve only the code and memories relevant to the current task |
+| **Isolate** | `oak_context` / `oak ci context` | Assemble just-in-time context for a specific task, pulling from code and memory |
+| **Consolidate** | `oak_resolve_memory` / `oak ci resolve` | Resolve stale observations to prevent context rot in the memory store |
+
+### Example workflow
+
+```bash
+# WRITE: Store a discovery for future sessions
+oak ci remember "Payment service retries 3x with exponential backoff" --type discovery
+# SELECT: Find relevant code for a task
+oak ci search "payment retry logic" --type code -n 5
+# ISOLATE: Assemble just-in-time context
+oak ci context "fix payment timeout bug" -f src/services/payment.py
+# CONSOLIDATE: Clean up after fixing
+oak ci resolve <memory-id>
+```
+
+## Before/After Gallery
+
+### Vague prompt to structured prompt
+
+**Before:** `Write tests for the user service.`
+
+**After:**
+```xml
+<task>Write unit tests for UserService: create_user, get_user_by_email, delete_user.</task>
+<constraints>
+- pytest with fixtures for setup/teardown
+- Test success and error paths for each method
+- Mock external API calls (email verification)
+- Descriptive test names: test_create_user_with_duplicate_email_raises_conflict
+</constraints>
+```
+
+### Bloated system prompt to altitude-optimized
+
+**Before** (micromanaging): "Always use f-strings. Always use pathlib. Always use type hints. Use black with line length 88. Use dataclasses for DTOs. Never use print()..."
+
+**After** (right altitude):
+```xml
+<role>You are a Python developer working in this project.</role>
+<principles>
+- Follow existing patterns. Find the closest implementation and mirror its style.
+- Prefer modern Python (3.10+). When in doubt, check what the codebase uses.
+- Write code that reads clearly without comments. Comment only non-obvious "why" decisions.
+</principles>
+<quality>Run `make check` before considering any change complete.</quality>
+```
+
+### Context-stuffed agent to compress + isolate
+
+**Before:** 40,000 tokens (2K rules + 3K README + 8K tool descriptions + 12K API docs + 15K conversation = half irrelevant)
+
+**After:** 8,000 tokens (800 altitude-optimized prompt + 1,200 for 5 relevant tools + 2,000 retrieved context + 4,000 compressed conversation = all relevant)
+
+See `references/before-after-examples.md` for the full gallery with additional transformations.
+
+## When to Use What
+
+| Situation | Strategy | Key Technique | Reference |
+|-----------|----------|---------------|-----------|
+| Writing a new system prompt | Write | Altitude concept, canonical examples | `references/system-prompt-design.md` |
+| Prompt gives inconsistent results | Foundations | Add examples, use XML structure | `references/prompt-foundations.md` |
+| Agent losing track of goals | Compress | Conversation summarization, compaction | `references/context-engineering-framework.md` |
+| Agent context window filling up | Isolate | Just-in-time retrieval, progressive disclosure | `references/agent-context-patterns.md` |
+| Agent forgetting earlier decisions | Write + Compress | Pin critical context, summarize history | `references/memory-and-sessions.md` |
+| Need to measure prompt quality | Evaluate | A/B testing, rubric scoring | `references/evaluation-and-testing.md` |
+| Setting project-wide AI rules | Write | Constitution as system prompt | `/project-governance` skill |
+| Agent repeating mistakes across sessions | Write | Memory-as-a-tool, `oak_remember` | `references/memory-and-sessions.md` |
+| Complex multi-step reasoning | Foundations | Chain of thought, extended thinking | `references/prompt-foundations.md` |
+| Output format is wrong | Foundations | Examples (multishot), XML tags | `references/prompt-foundations.md` |
+
+## Deep Dives
+
+For detailed guidance on specific topics, consult the reference documents:
+
+- **`references/prompt-foundations.md`** -- Core prompt engineering techniques with examples and anti-patterns
+- **`references/context-engineering-framework.md`** -- The four strategies (Write, Select, Compress, Isolate) in depth
+- **`references/agent-context-patterns.md`** -- Sessions, memory types, context rot, and compaction strategies
+- **`references/system-prompt-design.md`** -- System prompt anatomy, the altitude concept, and reusable templates
+- **`references/memory-and-sessions.md`** -- Memory types, the memory-as-a-tool pattern, and OAK CI integration
+- **`references/before-after-examples.md`** -- Extended gallery of prompt and context transformations
+- **`references/evaluation-and-testing.md`** -- Measuring prompt quality, A/B testing, and iterative improvement

--- a/.codex/skills/context-engineering/references/agent-context-patterns.md
+++ b/.codex/skills/context-engineering/references/agent-context-patterns.md
@@ -1,0 +1,508 @@
+# Agent Context Patterns
+
+Context management patterns for AI agents: autonomous systems that take actions over multiple turns, read and write files, call tools, and maintain state across interactions. These patterns draw from Google's "Context Engineering: Sessions & Memory" whitepaper by Kimberly Milam & Antonio Gulli, and from production agent architectures.
+
+---
+
+## Sessions vs Memory
+
+Sessions and memory serve fundamentally different roles in agent context. Conflating them leads to either bloated sessions (stuffing everything into the conversation) or amnesia (losing hard-won knowledge between conversations).
+
+| Concept | Sessions | Memory |
+|---|---|---|
+| Lifetime | Single conversation | Across conversations |
+| Scope | Turn-by-turn interaction | Persistent knowledge |
+| Storage | Conversation history (in-context) | External database or file store |
+| Growth | Linear with turns | Curated, relatively stable |
+| Example | Chat messages, tool results | Learned preferences, past decisions, gotchas |
+
+### Session Architecture
+
+Each session is one continuous interaction with a goal. The session context grows with every turn: user message, assistant response, tool calls and their results.
+
+A well-structured session has three phases:
+
+1. **Start**: Goal is established, relevant context is loaded (system prompt, retrieved memories, relevant files).
+2. **Middle**: Work happens. Tool calls, reasoning, intermediate results accumulate.
+3. **End**: Outcome is reached. Learnings are extracted and stored to memory.
+
+Session metadata worth tracking:
+
+- Start time and duration
+- Agent ID and model used
+- Tools invoked (names and counts)
+- Files read and written
+- Tokens consumed (input + output)
+- Outcome: completed, failed, abandoned
+- Cost (if available)
+
+This metadata becomes the raw material for episodic memory. OAK CI captures this automatically via `agent_runs` and `sessions` tables.
+
+### Session Boundaries
+
+Deciding when to start a new session vs. continue an existing one:
+
+**Start a new session when:**
+- The user's goal has fundamentally changed
+- The previous session ended with a clear outcome
+- Context has grown past the compaction threshold and a clean start is cheaper than summarization
+- A different agent or model is better suited to the new task
+
+**Continue the existing session when:**
+- The new request builds directly on prior work
+- Relevant context (variable bindings, file state, intermediate results) would be lost
+- The user explicitly asks to continue
+
+**Session continuity** (bridging sessions):
+- Generate a session summary at the end of each session
+- Store key decisions, files touched, and open questions
+- Load this summary at the start of the next related session
+- This is cheaper than maintaining a massive continuous context
+
+---
+
+## Context Rot
+
+Context rot is the degradation of model performance as the context window fills. It is **not linear** -- performance holds steady for a while, then falls off a cliff.
+
+### The Degradation Curve
+
+Empirical behavior across major LLMs:
+
+```
+Performance
+  |████████████████████████
+  |                        ████████
+  |                                ████
+  |                                    ███
+  |                                       ██
+  |                                         █
+  |__________________________________________|___
+  0%        30%       50%       70%      100%
+                Context Window Usage
+```
+
+- **0-35% capacity**: Performance is roughly constant. The model handles instructions, history, and retrieval well.
+- **35-65% capacity**: Gradual degradation. The model starts missing details in the middle of context.
+- **65-80% capacity**: Noticeable decline. Instruction-following weakens, hallucinations increase.
+- **80%+ capacity**: Sharp decline. The model may ignore instructions, contradict itself, or lose track of the goal.
+
+These thresholds vary by model and task. Complex reasoning tasks degrade earlier than simple retrieval tasks.
+
+### Position Bias
+
+Models do not attend equally to all positions in the context window:
+
+- **Primacy effect**: Content at the beginning of context (system prompt, first instructions) gets disproportionate attention.
+- **Recency effect**: Content at the end (most recent messages) also gets strong attention.
+- **Lost in the middle**: Content in the middle of a long context receives the least attention.
+
+**Mitigations:**
+
+1. Place critical instructions in the system prompt (beginning of context).
+2. Repeat key instructions or constraints near the end of context, especially after compaction.
+3. Use XML tags or markdown headers to create clear section boundaries -- these act as attention anchors.
+4. When retrieving context, place the most relevant items closest to the current turn (end of context).
+
+### Causes of Context Rot
+
+| Cause | Mechanism | Mitigation |
+|---|---|---|
+| Token accumulation | Context window fills with conversation history | Compaction or summarization before 60% capacity |
+| Instruction dilution | Instructions become a smaller percentage of total context | Repeat key instructions; use XML section tags |
+| Contradictory information | Earlier context conflicts with later corrections | Explicit "latest wins" rules; remove outdated content |
+| Tool result bloat | Verbose tool outputs (file contents, search results) consume tokens | Summarize tool results after processing; drop raw output |
+| Goal drift | Original goal buried under conversation noise | Maintain a goal scratchpad; restate goals after compaction |
+| Retrieval noise | Irrelevant retrieved context dilutes signal | Filter retrieval results aggressively; prefer precision over recall |
+
+---
+
+## Multi-Agent Session Management
+
+When multiple agents collaborate, context management becomes a distributed systems problem. Three fundamental patterns exist.
+
+### Pattern 1: Shared Context
+
+All agents read from and write to the same context window (or shared document).
+
+```
+┌─────────────────────────────────┐
+│        Shared Context           │
+│  ┌───────┐ ┌───────┐ ┌───────┐ │
+│  │Agent A│ │Agent B│ │Agent C│ │
+│  └───────┘ └───────┘ └───────┘ │
+└─────────────────────────────────┘
+```
+
+**Strengths:**
+- All agents see the full picture
+- No communication overhead
+- Simple to implement
+
+**Weaknesses:**
+- Context bloats N times faster (each agent's output adds to shared context)
+- Agents may contradict each other
+- Hard to scale past 2-3 agents
+- No isolation: one agent's verbose output degrades context for all
+
+**Best for:** Small teams of tightly-coupled agents working on the same artifact.
+
+### Pattern 2: Separate Contexts (Isolation)
+
+Each agent has its own context window. Communication happens via structured messages.
+
+```
+┌───────────┐   message   ┌───────────┐
+│  Agent A   │ ──────────→ │  Agent B   │
+│  (own ctx) │ ←────────── │  (own ctx) │
+└───────────┘             └───────────┘
+```
+
+**Strengths:**
+- Each agent gets focused, relevant context
+- No cross-contamination
+- Scales to many agents
+- Agents can use different models optimized for their task
+
+**Weaknesses:**
+- Communication overhead (messages must be explicit)
+- Risk of information loss at boundaries
+- Harder to coordinate complex multi-step work
+
+**Best for:** Diverse tasks where each agent needs specialized context (e.g., one agent researches, another codes, another reviews).
+
+### Pattern 3: Hybrid (Orchestrator + Workers)
+
+An orchestrator agent maintains shared state. Worker agents operate in isolation with task-specific context. Results flow back through the orchestrator.
+
+```
+              ┌──────────────┐
+              │ Orchestrator  │
+              │ (shared state)│
+              └──┬───┬───┬──┘
+                 │   │   │
+          ┌──────┘   │   └──────┐
+          ▼          ▼          ▼
+    ┌──────────┐ ┌──────────┐ ┌──────────┐
+    │ Worker A  │ │ Worker B  │ │ Worker C  │
+    │ (own ctx) │ │ (own ctx) │ │ (own ctx) │
+    └──────────┘ └──────────┘ └──────────┘
+```
+
+**Strengths:**
+- Workers get clean, focused context (no pollution from other workers)
+- Orchestrator maintains the big picture
+- Workers can run in parallel
+- Scales well
+
+**Weaknesses:**
+- Orchestrator context can still bloat if many workers report back
+- Design complexity: must define clear task boundaries and result formats
+
+**Best for:** Production agent systems. This is the pattern used by Claude Code's team mode, OAK's analysis agents, and most multi-agent frameworks.
+
+### Choosing a Pattern
+
+| Factor | Shared | Isolated | Hybrid |
+|---|---|---|---|
+| Number of agents | 2-3 | Any | Any |
+| Task coupling | Tight | Loose | Mixed |
+| Context efficiency | Low | High | High |
+| Implementation effort | Low | Medium | High |
+| Scalability | Poor | Good | Good |
+
+---
+
+## Compaction Strategies
+
+When context grows too large, you must compact it. The strategy you choose determines what knowledge survives compression.
+
+### Strategy 1: Last-N Messages
+
+Keep only the most recent N conversation turns. Discard everything older.
+
+**How it works:**
+```
+Before: [msg1, msg2, msg3, msg4, msg5, msg6, msg7, msg8]
+After (N=4): [msg5, msg6, msg7, msg8]
+```
+
+**Characteristics:**
+- Simple and predictable
+- Token usage is bounded
+- Completely loses early context (instructions, goals, decisions made early)
+- No computation overhead
+
+**Best for:** Stateless chat applications, simple Q&A bots, situations where early context is truly irrelevant.
+
+**Not suitable for:** Multi-step tasks where early instructions or decisions matter.
+
+### Strategy 2: Recursive Summarization
+
+Summarize old messages into a running summary. Keep the summary plus recent messages.
+
+**How it works:**
+```
+Before: [summary_v1, msg4, msg5, msg6, msg7, msg8, msg9, msg10]
+Trigger: context > 60% capacity
+After:  [summary_v2 (covers msg1-msg7), msg8, msg9, msg10]
+```
+
+Where `summary_v2` incorporates `summary_v1` and `msg4-msg7` into a new summary.
+
+**Characteristics:**
+- Preserves a compressed version of all history
+- Moderate token efficiency
+- Risk: summarization losses compound over time (the "telephone game" effect)
+- Each compaction step loses some fidelity
+- Works best when the model doing summarization is high quality
+
+**Implementation guidance:**
+- Trigger summarization at 55-65% context capacity (before degradation begins)
+- Use structured summaries: decisions made, files changed, open questions, key facts
+- Include explicit section for "instructions that must be preserved"
+- Consider having the summary reviewed/approved before discarding originals
+
+### Strategy 3: Manus Hybrid (Structured Scratchpad)
+
+Maintain two zones: a **verbatim zone** (recent turns, kept as-is) and a **summary zone** (older turns, compressed). Alongside both, maintain a **structured scratchpad** that is never summarized.
+
+**How it works:**
+```
+Context layout:
+┌─────────────────────────────┐
+│ System Prompt (fixed)        │
+├─────────────────────────────┤
+│ Scratchpad (preserved)       │
+│  - Current goal              │
+│  - Key facts learned         │
+│  - Decisions made            │
+│  - Open questions            │
+│  - Files modified            │
+├─────────────────────────────┤
+│ Summary Zone (compressed)    │
+│  "Earlier: researched auth   │
+│   options, chose JWT..."     │
+├─────────────────────────────┤
+│ Verbatim Zone (recent turns) │
+│  [msg8, msg9, msg10]         │
+└─────────────────────────────┘
+```
+
+**Characteristics:**
+- Highest context preservation of any compaction strategy
+- The scratchpad acts as a lossless knowledge store across compactions
+- More complex to implement: requires maintaining the scratchpad format
+- The scratchpad itself must be kept concise (it is never compressed)
+
+**Implementation guidance:**
+- Define scratchpad structure upfront (what sections, what format)
+- Update the scratchpad explicitly during the session (not just at compaction time)
+- On compaction: compress the narrative (conversation), but copy the scratchpad verbatim
+- Cap scratchpad size (e.g., 2000 tokens) to prevent it from becoming its own bloat problem
+
+### Strategy Comparison
+
+| Strategy | Context Preservation | Simplicity | Token Efficiency | Compounding Loss | Best For |
+|---|---|---|---|---|---|
+| Last-N | Low | High | High | None (hard cutoff) | Short tasks, chat |
+| Recursive Summarization | Medium | Medium | Medium | Yes (telephone game) | Medium-length sessions |
+| Manus Hybrid | High | Low | Medium | Minimal (scratchpad preserved) | Complex multi-step tasks |
+| Full (no compaction) | Perfect | Highest | Lowest | N/A | Sessions under 30% capacity |
+
+**Rule of thumb:** If your agent sessions routinely exceed 50% context capacity, you need a compaction strategy. If they involve multi-step reasoning or long-running tasks, prefer the Manus Hybrid approach.
+
+---
+
+## Memory Architecture (5 Layers)
+
+From Google's whitepaper, agent memory has five layers, analogous to human memory systems. Each layer has different lifetime, retrieval characteristics, and storage requirements.
+
+### Layer 1: Sensory Memory (Immediate Context)
+
+The current turn's raw input: the user's latest message, tool results just returned, documents just retrieved.
+
+- **Lifetime:** Single turn
+- **Size:** Small (one turn's worth of data)
+- **Analogy:** What you are looking at right now
+- **Implementation:** The latest entries in the conversation messages array
+- **Key concern:** Filter aggressively. Not everything the tools return needs to stay in context.
+
+### Layer 2: Short-Term Memory (Session Context)
+
+The conversation history within the current session. Grows with each turn.
+
+- **Lifetime:** Current session
+- **Size:** Grows linearly; subject to context rot
+- **Analogy:** What you have been thinking about for the last hour
+- **Implementation:** The conversation messages array, subject to compaction
+- **Key concern:** This is where context rot lives. Apply compaction strategies from the previous section.
+
+### Layer 3: Episodic Memory (What Happened)
+
+Records of past events and experiences. Retrieved when relevant to the current task.
+
+- **Lifetime:** Long-term (persists across sessions)
+- **Content:** Specific events: "Last time we refactored the auth module, tests broke because mock setup was order-dependent"
+- **Retrieval:** Semantic search triggered by current task context
+- **OAK CI equivalent:** `memory_observations` with types `bug_fix` and `gotcha`
+- **Key concern:** Must be retrievable by relevance, not just recency. Vector search is preferred.
+
+### Layer 4: Semantic Memory (Facts and Concepts)
+
+General knowledge about the domain, the codebase, or the project. Relatively stable over time.
+
+- **Lifetime:** Long-term, updated infrequently
+- **Content:** "This codebase uses the repository pattern for data access" or "The API rate limit is 100 requests per minute"
+- **Retrieval:** Semantic search, or loaded proactively based on file/topic context
+- **OAK CI equivalent:** `memory_observations` with types `discovery` and `decision`
+- **Key concern:** Keep entries atomic and factual. Vague or compound observations degrade search quality.
+
+### Layer 5: Procedural Memory (How To Do Things)
+
+Skills, procedures, and workflows. The agent's "muscle memory."
+
+- **Lifetime:** Permanent (updated with project evolution)
+- **Content:** "To add a new API endpoint: create route file, add service, write tests, update OpenAPI spec"
+- **Implementation:** System prompts, constitution files, skill files, templates
+- **OAK CI equivalent:** Constitution (`oak/constitution.md`), skill files, agent task definitions
+- **Key concern:** This is the most valuable memory layer. It should be curated by humans, not auto-generated.
+
+### How the Layers Integrate
+
+At each turn, the agent assembles context from all five layers:
+
+```
+Context Assembly (per turn):
+
+  Layer 5: System prompt + skill instructions    [always present, fixed cost]
+      │
+  Layer 4: Retrieved semantic memories           [loaded at session start or on topic change]
+      │
+  Layer 3: Retrieved episodic memories            [searched per-turn based on current task]
+      │
+  Layer 2: Session history (compacted)            [growing, subject to compaction]
+      │
+  Layer 1: Current turn input + tool results      [fresh each turn]
+      │
+      ▼
+  ┌──────────────────┐
+  │  Model Inference  │
+  └──────────────────┘
+```
+
+**Token budget allocation** (approximate, for a 200K-token model):
+
+| Layer | Budget | Notes |
+|---|---|---|
+| Layer 5 (Procedural) | 10-20K tokens | System prompt, skills, constitution |
+| Layer 4 (Semantic) | 5-10K tokens | Retrieved facts, project knowledge |
+| Layer 3 (Episodic) | 3-5K tokens | Relevant past experiences |
+| Layer 2 (Session) | 50-100K tokens | Conversation history (compacted) |
+| Layer 1 (Sensory) | 10-30K tokens | Current tool results, retrieved docs |
+| Reserved for response | 10-30K tokens | Model's output budget |
+
+These are guidelines, not rules. Adjust based on your model's context window and task requirements.
+
+---
+
+## Practical Patterns for Agent Loops
+
+### The Observe-Think-Act-Reflect Loop
+
+The core agent loop with explicit context management at each phase:
+
+**1. Observe** -- Gather context before reasoning.
+- Retrieve relevant memories (`oak_search`, `oak_context`)
+- Read relevant files
+- Check task state and dependencies
+- Load any session scratchpad from prior compaction
+
+**2. Think** -- Reason about the gathered context.
+- Extended thinking / chain-of-thought helps here
+- Consider multiple approaches before acting
+- Identify what additional context might be needed
+
+**3. Act** -- Take action based on reasoning.
+- Write code, call APIs, modify files
+- Use tools to verify results (run tests, check output)
+- Keep tool calls focused: avoid retrieving more context than needed
+
+**4. Reflect** -- Store learnings from the outcome.
+- If something unexpected happened, store it as episodic memory (`oak_remember`)
+- Update the session scratchpad with new facts, decisions, and open questions
+- If a general pattern was discovered, store it as semantic memory
+
+This loop naturally integrates all five memory layers: Layer 5 provides the loop structure itself, Layers 3-4 feed the Observe phase, Layer 2 provides session continuity, and Layer 1 is the current turn's input.
+
+### Context Budget Management
+
+Monitor context usage and trigger compaction proactively:
+
+```
+Per-turn context check:
+
+  current_usage = system_prompt + session_history + retrieval + pending_response
+  capacity = model_context_window
+
+  if current_usage > 0.55 * capacity:
+      trigger_compaction()       # Summarize old turns, preserve scratchpad
+
+  if current_usage > 0.75 * capacity:
+      aggressive_compaction()    # Deeper summarization, drop tool results
+
+  if current_usage > 0.90 * capacity:
+      emergency_compaction()     # Keep only scratchpad + last 3 turns
+```
+
+**Key principle:** Compact early, compact often. It is better to summarize 10 turns when you have headroom than to be forced into emergency compaction that loses critical context.
+
+### Goal Persistence
+
+Goal drift is the most common cause of agent failure in long sessions. The original task gets buried under conversation history and the agent starts optimizing for the wrong thing.
+
+**Mitigations:**
+
+1. **Explicit goal statement**: Store the current goal in the session scratchpad. Not just "fix the bug" but "fix the authentication timeout bug in `auth_service.py` where JWT tokens expire during long-running requests."
+
+2. **Goal restatement**: After every compaction, restate the goal. After every N turns (e.g., 10), restate the goal.
+
+3. **Goal decomposition**: Break complex goals into sub-goals. Track which sub-goals are complete and which remain.
+
+4. **Completion criteria**: Define upfront what "done" looks like. "The fix is done when: (a) the timeout no longer occurs, (b) existing tests pass, (c) a new test covers the edge case."
+
+### When to Store Memories
+
+Not every observation deserves to be a memory. Store memories when:
+
+| Signal | Memory Type | Example |
+|---|---|---|
+| Something broke unexpectedly | `gotcha` | "Mocking `datetime.now()` in this codebase requires patching the module-level import, not `datetime.datetime.now`" |
+| A bug was fixed and the root cause was non-obvious | `bug_fix` | "The flaky test was caused by test ordering -- `test_auth` was leaking a database connection" |
+| An architectural pattern was discovered | `discovery` | "All API routes in this project use the decorator pattern from `base_route.py`" |
+| A deliberate choice was made between alternatives | `decision` | "Chose SQLite over PostgreSQL for CI data because it requires zero configuration and the data is machine-local" |
+| A trade-off was identified | `trade_off` | "Compacting at 55% capacity loses less context but triggers more frequent compactions, increasing latency" |
+
+**Do not store:**
+- Obvious facts anyone could find by reading the code
+- Session-specific state that will not be relevant later
+- Speculative conclusions from reading a single file
+- Anything already documented in the project's constitution or README
+
+---
+
+## Key Takeaways
+
+1. **Sessions are ephemeral; memory is durable.** Do not try to make sessions do the job of memory, or vice versa.
+
+2. **Context rot is non-linear.** Performance holds steady, then falls off a cliff. Compact before you hit the cliff, not after.
+
+3. **Position matters.** Put critical instructions at the start and end of context. Use structural markers (XML tags, headers) to create attention anchors.
+
+4. **Prefer the hybrid pattern** for multi-agent systems. Isolation protects each agent's context quality; the orchestrator maintains coherence.
+
+5. **Compaction is not optional** for long-running agents. Choose a strategy that preserves structured knowledge (decisions, goals, facts) even as narrative history is compressed.
+
+6. **Memory has layers.** Procedural memory (skills, constitution) is the most valuable. Episodic memory (what happened) is the most underused. Invest in both.
+
+7. **Goals drift. State them explicitly, restate them often.** A scratchpad with the current goal, sub-goals, and completion criteria prevents the most common mode of agent failure.

--- a/.codex/skills/context-engineering/references/before-after-examples.md
+++ b/.codex/skills/context-engineering/references/before-after-examples.md
@@ -1,0 +1,331 @@
+# Before/After Examples
+
+Concrete transformations showing how context engineering techniques improve real prompts. Each example: **Before** (problematic), **Diagnosis** (what's wrong), **Techniques Applied**, **After** (improved).
+
+---
+
+## 1. Vague Prompt to Structured Prompt
+
+### Before
+```
+Help me with this code. It's not working right and I need it fixed.
+```
+
+### Diagnosis
+- "Not working" gives zero actionable detail -- no code, no error, no expected behavior
+- No output format specified
+
+### Techniques Applied
+- **Be Clear and Direct**: state the exact problem and expected vs actual behavior
+- **XML Tags**: separate code, error, and instructions
+
+### After
+```xml
+<code language="python">
+def calculate_discount(price, tier):
+    if tier == "gold": return price * 0.8
+    if tier == "silver": return price * 0.9
+    return price
+</code>
+
+<error>calculate_discount(100, "Gold") returns 100 instead of 80.</error>
+
+<instructions>
+1. Identify why the function fails for "Gold" (capital G)
+2. Fix the bug
+3. Add handling for invalid tier values (return price unchanged, log a warning)
+</instructions>
+
+<output_format>Root cause (one sentence), fixed code, test cases.</output_format>
+```
+
+**Why it works:** The model knows exactly what is broken, what the expected behavior is, and what to produce. No ambiguity about scope or success criteria.
+
+---
+
+## 2. Wall of Text to XML-Structured Context
+
+### Before
+```
+Here's my API spec and some error logs and the database schema. The API
+spec says we have a /users endpoint that accepts POST with name and email.
+The email should be unique. Here are the error logs: [2024-01-15 14:23:01]
+IntegrityError: duplicate key violates "users_email_key" Request: POST
+/users {"name": "Jane", "email": "jane@test.com"} And the schema is
+CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT
+NOT NULL UNIQUE). Why am I getting these errors?
+```
+
+### Diagnosis
+- Three data sources in one paragraph with no separation
+- Question buried at the end -- model reads data without knowing the goal
+
+### Techniques Applied
+- **XML Tags**: each data source in its own labeled section
+- **Long Context Tips**: front-load the question
+
+### After
+```xml
+<question>
+Why do duplicate key errors occur on POST /users? Provide: root cause, fix, error response.
+</question>
+
+<error_logs>
+[2024-01-15 14:23:01] IntegrityError: duplicate key violates "users_email_key"
+  Request: POST /users {"name": "Jane", "email": "jane@test.com"}
+[2024-01-15 14:25:12] IntegrityError: duplicate key violates "users_email_key"
+  Request: POST /users {"name": "John", "email": "jane@test.com"}
+</error_logs>
+
+<database_schema>
+CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL UNIQUE);
+</database_schema>
+
+<api_spec>POST /users — Body: { name, email } — email must be unique</api_spec>
+```
+
+**Why it works:** Each data source is labeled. The question is front-loaded so the model reads data with the goal already in mind.
+
+---
+
+## 3. Bloated System Prompt to Altitude-Optimized
+
+### Before (22 generic directives)
+```
+You are an AI assistant. Be helpful, harmless, honest. Be polite.
+Use clear language. Be concise but thorough. Prioritize accuracy.
+Always cite sources. Be creative when appropriate. Ask clarifying
+questions. Be empathetic. Use examples. Stay on topic. [... 10 more ...]
+```
+
+### Diagnosis
+- None specific enough to change behavior -- "be helpful" is default
+- Contradictions: "be concise" vs "be thorough"
+- No role, no domain, no output conventions
+
+### Techniques Applied
+- **Altitude optimization**: raise to principled guidance
+- **System prompt design**: define role with domain expertise
+
+### After
+```xml
+<role>
+Code reviewer. Domain: Django REST APIs with PostgreSQL. Senior level.
+</role>
+
+<constraints>
+- Flag security issues as CRITICAL regardless of other priorities
+- If a change affects schema, always mention migration safety
+- When trade-offs exist, state both options and recommend one
+- Say "I'm not sure" rather than guessing on library-specific behavior
+</constraints>
+
+<output_conventions>
+- Reference file:line_number for each finding
+- Severity: CRITICAL, WARNING, SUGGESTION
+- Include corrected code for CRITICAL and WARNING items
+</output_conventions>
+```
+
+**Why it works:** 22 vague directives became 7 specific rules. Generic advice is gone; domain-specific guidance takes its place.
+
+---
+
+## 4. Context-Stuffed Agent to Compress and Isolate
+
+### Before
+```
+System prompt permanently includes:
+- Full API docs (8K tokens), database schema (3K), error codes (2K),
+  coding standards (1.5K), changelog (4K) = ~18,500 tokens always loaded
+```
+
+### Diagnosis
+- Most reference data used rarely (~5% per conversation)
+- 18K tokens permanently occupied; position bias weakens middle sections
+- Stale data in the system prompt is worse than no data
+
+### Techniques Applied
+- **Isolate**: move reference data behind tool calls
+- **Compress**: summarize what remains
+- **Select**: retrieve only what the current query needs
+
+### After
+```
+System prompt (800 tokens): role, principles, tool instructions
+
+Tools:
+- search_api_docs(endpoint) -> docs for one endpoint
+- query_schema(table_name) -> schema for one table
+- lookup_error_code(code) -> one error definition
+- get_coding_standards(topic) -> relevant standards
+```
+
+**Why it works:** 18,500 to 800 tokens (95% reduction). Data always current (retrieved live). Model attention focused. Cost drops proportionally.
+
+---
+
+## 5. Stateless Agent to Memory-Augmented
+
+### Before
+```
+User: "Can you help me with the auth module?"
+Agent: Starts from scratch. Doesn't know about the circular import
+       bug fixed last week or the refactor merged yesterday.
+```
+
+### Diagnosis
+- No persistent memory -- each session reinvents the wheel
+- Same gotchas hit repeatedly; user re-explains context every time
+
+### Techniques Applied
+- **Write**: store observations as they emerge
+- **Select**: retrieve relevant memories at session start
+
+### After
+```
+Session start: Agent receives injected context:
+  - Recent session summaries, active gotchas, unresolved observations
+
+During work: Agent stores learnings:
+  oak_remember("Auth circular import caused by module-level import
+  of UserModel. Fixed by moving inside function.",
+  memory_type="bug_fix", context="src/services/auth_service.py")
+
+Next session: "Help with the auth module?"
+  Agent already knows about the circular import and last week's refactor.
+```
+
+**Why it works:** The agent compounds knowledge across sessions. Gotchas caught once stay caught.
+
+---
+
+## 6. Poor Few-Shot to Diverse Multishot
+
+### Before (2 trivial examples)
+```
+Convert descriptions to SQL queries.
+Example: "Get all users" -> SELECT * FROM users;
+Example: "Get active users" -> SELECT * FROM users WHERE active = true;
+Now convert: "Get the top 5 customers by total spending last quarter"
+```
+
+### Diagnosis
+- 2 examples, both trivially simple (single table, no joins)
+- Actual task requires JOIN, GROUP BY, ORDER BY, LIMIT, date filtering
+- No schema -- model guesses table and column names
+
+### Techniques Applied
+- **Multishot examples**: 5 diverse examples, simple to complex
+- **XML Tags**: structure examples and provide schema
+
+### After
+```xml
+Convert natural language to PostgreSQL using this schema:
+
+<schema>
+users(id, name, email, created_at)
+orders(id, user_id, total_amount, created_at, status)
+products(id, name, price, category)
+order_items(order_id, product_id, quantity)
+</schema>
+
+<examples>
+<example>
+<input>Get all users</input>
+<output>SELECT * FROM users;</output>
+</example>
+<example>
+<input>Active orders with user names</input>
+<output>SELECT u.name, o.id, o.total_amount
+FROM orders o JOIN users u ON u.id = o.user_id WHERE o.status = 'active';</output>
+</example>
+<example>
+<input>Count orders per user, highest first</input>
+<output>SELECT u.name, COUNT(o.id) AS order_count
+FROM users u LEFT JOIN orders o ON o.user_id = u.id
+GROUP BY u.id, u.name ORDER BY order_count DESC;</output>
+</example>
+<example>
+<input>Revenue by product category this year</input>
+<output>SELECT p.category, SUM(oi.quantity * p.price) AS revenue
+FROM order_items oi JOIN products p ON p.id = oi.product_id
+JOIN orders o ON o.id = oi.order_id
+WHERE o.created_at >= DATE_TRUNC('year', CURRENT_DATE)
+GROUP BY p.category ORDER BY revenue DESC;</output>
+</example>
+<example>
+<input>Users who never placed an order</input>
+<output>SELECT u.name, u.email FROM users u
+LEFT JOIN orders o ON o.user_id = u.id WHERE o.id IS NULL;</output>
+</example>
+</examples>
+
+<input>Get the top 5 customers by total spending last quarter</input>
+```
+
+**Why it works:** Examples progress simple to complex, covering JOINs, GROUP BY, LEFT JOIN for negation, date functions. Schema is explicit.
+
+---
+
+## 7. Unconstrained Output to Prefilled and Formatted
+
+### Before
+```
+Analyze this error log and tell me what happened.
+[error log contents]
+```
+
+### Diagnosis
+- No output structure -- could be a paragraph, list, or narrative
+- "What happened" is open-ended; no actionable structure
+
+### Techniques Applied
+- **Output format**: define exact structure expected
+- **Be Clear and Direct**: bound the scope of analysis
+
+### After
+```xml
+<instructions>
+Analyze this error log. Identify root cause, impact, and fix.
+Respond in exactly this JSON format -- no additional commentary.
+</instructions>
+
+<error_log>[error log contents]</error_log>
+
+<output_format>
+{
+  "root_cause": {
+    "error": "specific error message",
+    "location": "file:line or service",
+    "explanation": "one sentence"
+  },
+  "impact": {
+    "user_facing": "what the user experienced",
+    "scope": "affected users/requests if determinable"
+  },
+  "fix": {
+    "immediate": "what to do now",
+    "preventive": "what to change to prevent recurrence"
+  }
+}
+</output_format>
+```
+
+**Why it works:** The JSON schema acts as a contract. The model produces parseable output, and the three-part structure ensures analysis is actionable, not just descriptive.
+
+---
+
+## Pattern Summary
+
+| Transformation | Key Technique | Typical Improvement |
+|---|---|---|
+| Vague to Structured | Clarity + XML tags | Consistent, relevant responses |
+| Wall of text to XML sections | XML structure | Better information extraction |
+| Low altitude to Right altitude | Altitude optimization | Smaller prompt, better adherence |
+| Context-stuffed to Tool-based | Isolate + Select | 90%+ token reduction, fresher data |
+| Stateless to Memory-augmented | Write + Select | Compounding effectiveness over time |
+| Single example to Diverse multishot | Multishot examples | Edge case handling, format consistency |
+| Unconstrained to Formatted | Output format + Prefill | Parseable, actionable output |
+
+Each transformation applies techniques from [Prompt Engineering Foundations](prompt-foundations.md). For system-level patterns, see [System Prompt Design](system-prompt-design.md). For agent-specific strategies, see [Agent Context Patterns](agent-context-patterns.md).

--- a/.codex/skills/context-engineering/references/context-engineering-framework.md
+++ b/.codex/skills/context-engineering/references/context-engineering-framework.md
@@ -1,0 +1,255 @@
+# The Context Engineering Framework
+
+Context engineering is designing the complete information environment a model receives at inference time. Four core strategies — Write, Select, Compress, Isolate — ensure the model has the right information, in the right form, at the right moment.
+
+## The Core Insight
+
+Context engineering is not prompt engineering. A prompt is what you type. Context is *everything* the model sees: system prompt + conversation history + tool definitions + tool results + retrieved documents + injected memories + file contents + structured metadata.
+
+A well-engineered prompt inside poorly-engineered context will underperform. A mediocre prompt inside well-engineered context will often succeed. **The context is the product.**
+
+The question shifts from "What should I tell the model?" to "What should the model see, and when should it see it?"
+
+---
+
+## Strategy 1: Write — Craft the Persistent Context
+
+The system prompt persists across every turn, anchoring behavior, tone, and decision-making. It is the highest-leverage piece of context.
+
+### The Altitude Scale
+
+Altitude is the level of abstraction at which you write instructions. Most system prompts fail because they target the wrong altitude.
+
+| Level | Example | Problem |
+|---|---|---|
+| Too High (30,000 ft) | "Be a helpful coding assistant" | No actionable guidance |
+| Too Low (ground level) | "Always use 4-space indentation, prefer f-strings over .format(), use pathlib instead of os.path" | Brittle, doesn't generalize, model may ignore the list |
+| Right Altitude (10,000 ft) | "Follow the project's existing code style. When uncertain, match the patterns in nearby files." | Principled, adaptable, scales to new situations |
+
+Right-altitude examples across domains:
+
+| Domain | Too High | Right Altitude |
+|---|---|---|
+| Code review | "Review code carefully" | "Identify bugs that would cause runtime failures, focusing on edge cases the author likely didn't test" |
+| Customer support | "Help the customer" | "Acknowledge the customer's specific situation before moving to resolution. Gather account info early." |
+| Data analysis | "Analyze this data" | "Check for quality issues first (missing values, type mismatches), then answer using appropriate aggregations" |
+| Writing | "Help me write" | "Match the style of the user's existing text. Preserve their voice; improve clarity without imposing a formula." |
+
+**The altitude test:** If your instruction would still be correct after the codebase or domain changes significantly, it is at the right altitude. If it would break, it is too low. If it provides no guidance for concrete decisions, it is too high.
+
+### Canonical Examples in System Prompts
+
+Instructions tell the model what to do. Examples *show* it. When the two conflict, examples usually win — models pattern-match on demonstrations more reliably than they follow abstract rules.
+
+Include 2-3 gold-standard input/output pairs directly in the system prompt:
+
+```
+You are a code review assistant.
+
+## Example Review
+
+**Input code:**
+def get_user(id):
+    user = db.query(f"SELECT * FROM users WHERE id = {id}")
+    return user[0]
+
+**Your review:**
+1. **SQL injection** (critical): Use parameterized queries:
+   `db.query("SELECT * FROM users WHERE id = ?", [id])`
+2. **Unhandled empty result** (bug): `user[0]` raises IndexError
+   if no user matches. Check the result length first.
+3. **Naming**: `id` shadows the built-in. Use `user_id`.
+
+Apply this structure: prioritize by severity, explain the why, show the fix.
+```
+
+This single example establishes the review structure, severity ordering, inline-fix convention, and explanatory tone — all by demonstration.
+
+### System Prompt as Constitution
+
+A system prompt can function as a constitution: a governing document establishing principles, boundaries, and quality standards for an entire project.
+
+> Cross-reference: The `/project-governance` skill creates constitutions that serve exactly this purpose — the Write strategy applied at project scale.
+
+---
+
+## Strategy 2: Select — Choose What Enters the Context
+
+Every token in the context window competes for the model's attention. Select ensures only high-value, relevant information occupies that space.
+
+### Minimal Viable Toolsets
+
+Fewer, well-described tools lead to better tool selection. Tool sprawl causes selection errors and wastes tokens.
+
+| Quality | Tool Description | Issue |
+|---|---|---|
+| Bad | "search: A tool for searching" | What does it search? What format? |
+| Bad | "find_and_replace_in_files: Searches and optionally replaces, supports regex, globs, recursive traversal" | Two tools in one |
+| Good | "grep_codebase: Search file contents with regex. Returns matching lines with file paths and line numbers." | Clear scope, output, use case |
+| Good | "edit_file: Replace a specific string in a file. old_string must appear exactly once." | Precise contract |
+
+**Principles:** single responsibility per tool, verb-based names, remove overlapping tools, conditionally load rarely-used tools.
+
+### Retrieval Quality
+
+RAG is the Select strategy operationalized. Quality matters far more than quantity.
+
+**Precision over recall.** Injecting 20 vaguely-related documents is worse than 3 highly relevant ones. Irrelevant results actively mislead by introducing noise that competes with signal.
+
+Key practices: re-rank after initial retrieval, limit to top-K (typically 3-5), chunk at semantic boundaries (sections, functions) not fixed token counts, test retrieval quality independently.
+
+### Dynamic Context Selection
+
+Route queries to different context sources based on what the query needs:
+
+```
+"I was charged twice"       -> billing KB + account lookup tool
+"App crashes on login"      -> troubleshooting docs + error log tool
+"How do I export my data?"  -> product docs + feature guide
+"I want to cancel"          -> retention playbook + account status tool
+```
+
+Implementation patterns: classify-then-select (two-step), model self-selection via tool descriptions, metadata pre-filtering, or combinations of these.
+
+---
+
+## Strategy 3: Compress — Reduce Without Losing
+
+Conversations grow. Tool results are verbose. Left unchecked, context fills and performance degrades. Compress fights context bloat while preserving essential information.
+
+### Compaction Techniques
+
+| Technique | How It Works | When to Use |
+|---|---|---|
+| Summarization | LLM summarizes older conversation history | Long conversations approaching limits |
+| Note-taking scratchpad | Agent writes key findings to a persistent scratchpad | Complex research tasks |
+| Sub-agent delegation | Spawn focused sub-agents with narrow context; receive only conclusions | Multi-domain tasks |
+| Tool result clearing | Replace verbose tool output with summary after processing | Large tool responses |
+| Recursive summarization | Summarize existing summaries | Very long sessions |
+
+### The Two-Phase Compression Approach
+
+A production pattern combining techniques:
+
+**Phase 1 — Sliding window:** Keep the last N messages verbatim (active working context).
+
+**Phase 2 — Structured summarization:** Compress older messages into: key facts established, decisions made with rationale, open questions, constraints discovered.
+
+This preserves detail where it matters most (recent context) while retaining essentials from earlier. Maintaining a "facts learned" scratchpad alongside the conversation enhances this — the scratchpad becomes a compressed representation of the entire session's knowledge.
+
+### Token Budget Analysis
+
+Budget tokens deliberately rather than filling the window opportunistically.
+
+```
+Available context = Window size - system prompt - tool descriptions
+                  - conversation history - retrieved docs - response budget
+```
+
+| Component | 8K | 32K | 128K | 200K |
+|---|---|---|---|---|
+| System prompt | 1,000 (12%) | 2,000 (6%) | 4,000 (3%) | 5,000 (2.5%) |
+| Tool descriptions | 500 (6%) | 1,500 (5%) | 3,000 (2%) | 4,000 (2%) |
+| Conversation | 2,500 (31%) | 12,000 (37%) | 50,000 (39%) | 80,000 (40%) |
+| Retrieved docs | 1,500 (19%) | 8,000 (25%) | 35,000 (27%) | 55,000 (27.5%) |
+| **Response budget** | **2,500 (31%)** | **8,500 (27%)** | **36,000 (28%)** | **56,000 (28%)** |
+
+**Rules:** Reserve 20-30% for response (truncation degrades quality). Compress proactively, not reactively. System prompt and tool descriptions are fixed costs; conversation and retrieved docs are where compression pays off.
+
+---
+
+## Strategy 4: Isolate — Move Information Out of Main Context
+
+The most powerful strategy for scaling. Move information to external storage, retrieve just-in-time. The context window becomes working memory, not permanent storage.
+
+### Just-in-Time Retrieval
+
+Don't load information until the model needs it.
+
+**Anti-pattern — eager loading:**
+```
+System prompt: full API docs (15K tokens) + style guide (3K)
+  + project rules (5K) + DB schema (4K) = 27K tokens before the user speaks
+```
+
+**Pattern — just-in-time:**
+```
+System prompt: role (200 tokens) + principles (300 tokens)
+  + tools: search_docs(), get_schema(), check_style() = 800 tokens
+  → detailed info retrieved on demand
+```
+
+97% fewer system prompt tokens, access to the same (or more) information.
+
+### Progressive Disclosure
+
+Structure information in layers:
+
+- **Layer 1 — Overview** (always in context): project structure, directory summaries
+- **Layer 2 — Details** (retrieved on demand): file listings with descriptions, section contents
+- **Layer 3 — Raw data** (retrieved for specific work): full file contents, complete records
+
+Each layer provides enough information to decide whether to go deeper — like navigating from a map to a neighborhood to a specific building.
+
+### Hybrid Context Loading
+
+- **Static context** (every turn): system prompt, core tools, persistent memory
+- **Dynamic context** (query-dependent): retrieved documents, relevant code files, user info
+- **Ephemeral context** (use once, then clear): raw tool results, intermediate search results, verbose API responses
+
+Most context is ephemeral — needed for one step, then dead weight. Actively managing context lifecycle (load, use, summarize, clear) keeps the window focused.
+
+---
+
+## Combining Strategies
+
+The four strategies work together. Decision framework:
+
+```
+Is the information needed on EVERY turn?
++-- Yes -> WRITE it into the system prompt
+|   +-- System prompt too long?
+|       +-- Yes -> Raise ALTITUDE or move specifics to retrieval
+|       +-- No  -> Keep it
++-- No -> Needed on SOME turns?
+    +-- Yes -> Can you predict WHEN?
+    |   +-- Yes -> SELECT (pre-filter by query type or metadata)
+    |   +-- No  -> ISOLATE (let model retrieve via tools)
+    +-- Rarely -> COMPRESS or remove entirely
+```
+
+**Combinations in practice:**
+
+| Scenario | Strategies |
+|---|---|
+| Long coding session | Write (project principles) + Isolate (file contents via tools) + Compress (summarize old turns) |
+| RAG-powered Q&A | Write (role + format) + Select (top-K docs) + Compress (multi-retrieval summaries) |
+| Research agent | Write (methodology) + Isolate (search tools) + Compress (scratchpad) + Select (curate findings) |
+| Customer support | Write (tone + policy) + Select (route to relevant KB) + Isolate (account lookup) |
+
+---
+
+## Measuring Context Quality
+
+| Signal | Likely Cause | Action |
+|---|---|---|
+| Model ignores instructions | System prompt too long or low altitude | Raise altitude, compress, move details to retrieval |
+| Wrong tool selected | Ambiguous or overlapping descriptions | Rewrite descriptions, reduce tool count |
+| Hallucinated information | Missing context | Add retrieval, improve selection |
+| Repetitive responses | Context rot (stale/redundant info) | Compress history, deduplicate |
+| Slow responses | Context too large | Compress, isolate verbose data |
+| Contradictory behavior | Conflicting instructions | Audit for contradictions, set precedence |
+| Degraded quality over time | Window filling with low-value history | Sliding-window compression, scratchpad |
+
+### Quick Diagnostic Checklist
+
+When agent performance drops, check in order:
+
+1. **System prompt over 3,000 tokens?** Raise altitude or isolate details.
+2. **More than 15 tools defined?** Reduce, merge, or conditionally load.
+3. **Conversation history over 50% of window?** Compress.
+4. **Retrieved documents relevant?** Spot-check what was actually injected.
+5. **Response budget sufficient?** Ensure 20-30% of window remains for output.
+6. **Contradictions present?** Search full context for conflicting instructions.
+
+Context engineering is iterative. Measure signals, diagnose root causes, apply strategies, measure again.

--- a/.codex/skills/context-engineering/references/evaluation-and-testing.md
+++ b/.codex/skills/context-engineering/references/evaluation-and-testing.md
@@ -1,0 +1,178 @@
+# Evaluation and Testing
+
+How to measure whether your context engineering is working and systematically improve it.
+
+---
+
+## Measuring Context Quality
+
+### Output Quality Dimensions
+
+| Dimension | What It Measures | How to Assess |
+|---|---|---|
+| Accuracy | Are facts and code correct? | Compare against ground truth, run tests |
+| Completeness | Does the response address the full request? | Checklist against requirements |
+| Consistency | Are responses stable across similar inputs? | Run same prompt 5-10 times, compare |
+| Relevance | Is the response focused on what was asked? | Check for tangential content |
+| Efficiency | Minimal tokens for maximum value? | Measure response length vs info density |
+| Format Compliance | Does output match specified format? | Validate against schema/template |
+
+Score each dimension independently on a 1-5 scale. A single aggregate score hides problems — a response can be accurate but verbose, or well-formatted but incomplete.
+
+### Context Quality Signals
+
+When outputs are poor, the cause is often in the context, not the model.
+
+| Signal | Indicates | Action |
+|---|---|---|
+| Model ignores late instructions | Position bias, context too long | Move instructions to start, add XML structure |
+| Hallucinated function names | Missing code context | Improve retrieval, add relevant files |
+| Generic responses | System prompt too high altitude | Lower altitude with more specific guidance |
+| Overly rigid responses | System prompt too low altitude | Raise altitude to principles |
+| Wrong tool selected | Ambiguous tool descriptions | Rewrite descriptions, reduce tool count |
+| Repeated similar answers | Context rot | Compress conversation, add diversity cues |
+| Contradicting earlier responses | Compaction lost key info | Improve compaction strategy, preserve decisions |
+
+---
+
+## A/B Testing Prompts
+
+### The Process
+1. **Baseline**: Run current prompt on 20-50 test cases, record outputs
+2. **Variant**: Modify one aspect of the prompt (not multiple changes at once)
+3. **Evaluate**: Score both sets on the quality dimensions above
+4. **Compare**: Statistical comparison (is the improvement consistent?)
+5. **Iterate**: Keep winner, test next hypothesis
+
+### What to A/B Test
+- System prompt wording (altitude changes)
+- Example selection (different multishot examples)
+- Output format instructions
+- XML structure vs plain text instructions
+- Tool descriptions
+- Context selection (which documents to include)
+- Compaction strategies
+
+### Single Variable Testing
+
+Change ONE thing at a time. If you change both the system prompt AND the examples, you can't attribute improvement to either change.
+
+| Round | Change | Measure |
+|---|---|---|
+| 1 | Add XML structure to prompt | Consistency, format compliance |
+| 2 | Add 3 multishot examples | Accuracy, edge case handling |
+| 3 | Raise system prompt altitude | Generalization, brevity |
+| 4 | Add retrieval for context | Accuracy, completeness |
+
+**Sample size matters.** Test on 20+ inputs to distinguish real improvement from noise. Record results for each round:
+
+```
+Round: 3
+Change: Replaced step-by-step instructions with principles
+Baseline: Accuracy 4.2, Completeness 3.8, Relevance 3.5
+Variant:  Accuracy 4.0, Completeness 3.6, Relevance 4.1
+Decision: Keep — relevance improved; add examples to recover completeness
+```
+
+---
+
+## Memory Metrics
+
+### Precision and Recall
+- **Precision**: Of the memories retrieved, how many were actually relevant?
+  - Low precision = noisy retrieval, irrelevant context injected
+  - Fix: Better embedding model, stricter similarity thresholds, re-ranking
+
+- **Recall**: Of the relevant memories that exist, how many were retrieved?
+  - Low recall = useful memories missed
+  - Fix: Better query formulation, lower similarity thresholds, multiple search strategies
+
+### Recall@K
+- Of the relevant memories, how many appear in the top K results?
+- Recall@5 is most important — agents rarely use more than 5 retrieved items effectively
+- Target: Recall@5 > 0.7 for your most common query types
+
+### Memory Quality Indicators
+
+| Metric | Healthy Range | Warning Sign |
+|---|---|---|
+| Active observations | Growing slowly | Explosive growth (>50/week) = low quality |
+| Resolution rate | 10-20% per month | 0% = never maintaining, >50% = storing too much trivia |
+| Retrieval relevance | >70% relevant in top 5 | <50% = classification or embedding problems |
+| Memory types distribution | Mix of all types | 90%+ one type = narrow capture |
+| Duplicate rate | <5% | >10% = not searching before storing |
+
+---
+
+## Iterative Improvement Workflow
+
+### The Feedback Loop
+
+```
+1. Identify a failure mode (wrong output, missed info, hallucination)
+   |
+   v
+2. Diagnose root cause (bad prompt? missing context? wrong retrieval?)
+   |
+   v
+3. Hypothesize fix (raise altitude? add examples? improve retrieval?)
+   |
+   v
+4. Apply ONE change
+   |
+   v
+5. Test on the original failure case + 5-10 similar cases
+   |
+   v
+6. Did it improve without regressing other cases?
+   |-- Yes -> Keep change, go to step 1 with next failure mode
+   |-- No  -> Revert change, try different hypothesis (step 3)
+```
+
+### Failure Mode to Root Cause Mapping
+
+| Failure Mode | Likely Root Cause | First Fix to Try |
+|---|---|---|
+| Model ignores instructions | Context too long, instructions buried | Compress context, move instructions to system prompt start |
+| Inconsistent output format | No examples of expected format | Add 3 multishot examples with exact output format |
+| Hallucinated information | Model lacking context it needs | Add retrieval (RAG) for the missing knowledge |
+| Correct but verbose | No conciseness instruction | Add explicit length/brevity constraint |
+| Handles common cases, fails edge cases | Examples only show happy path | Add edge case examples (2-3 tricky inputs) |
+| Works for simple queries, fails complex | Single-shot overload | Chain into multiple steps, add CoT |
+| Uses wrong tool | Tool descriptions overlap | Rewrite descriptions to be mutually exclusive |
+| Starts strong, degrades over time | Context rot | Add compaction at 60% capacity, repeat key instructions |
+| Different result each time | Underdetermined prompt | Add more constraints, examples, or structured output format |
+
+Prioritize fixes by **frequency** (how often it occurs), **severity** (how bad the outcome is), and **fixability** (can you address the root cause?). Fix high-frequency, high-severity issues first.
+
+---
+
+## Common Failure Modes
+
+| Failure Mode | Symptom | Category | Remedy |
+|---|---|---|---|
+| Prompt injection | Model ignores system prompt | Security | Input sanitization, separate user/system context |
+| Context overflow | Truncated or missing information | Capacity | Compress, isolate, select less |
+| Stale retrieval | Outdated information surfaces | Memory | Resolve/supersede old observations, refresh index |
+| Over-retrieval | Too many results injected | Selection | Stricter top-K, re-ranking |
+| Under-retrieval | Relevant information not found | Selection | Better embeddings, query expansion |
+| Goal drift | Agent forgets original task | Session | Goal scratchpad, periodic restatement |
+| Tool abuse | Model calls tools unnecessarily | Selection | Fewer tools, clearer descriptions |
+| Format drift | Output format degrades over conversation | Compression | Repeat format instructions after compaction |
+| Anchor bias | First example dominates outputs | Examples | Diverse examples, put the "typical" case second |
+| Sycophancy | Model agrees with incorrect user statements | System prompt | Add "push back when the user is wrong" instruction |
+
+---
+
+## Testing Checklist
+
+Before deploying a prompt/context configuration:
+
+- [ ] Tested on 10+ diverse inputs (not just the examples used in the prompt)
+- [ ] Edge cases covered: empty input, very long input, ambiguous input, off-topic input
+- [ ] Output format consistent across all test cases
+- [ ] No hallucinated information in any test output
+- [ ] Performance acceptable within token/cost budget
+- [ ] Compaction tested: still works after 20+ turns of conversation
+- [ ] Retrieval tested: correct memories/documents surface for test queries
+- [ ] Negative testing: model correctly refuses out-of-scope requests

--- a/.codex/skills/context-engineering/references/memory-and-sessions.md
+++ b/.codex/skills/context-engineering/references/memory-and-sessions.md
@@ -1,0 +1,244 @@
+# Memory and Sessions
+
+This reference covers how to use memory effectively in agent-assisted development: the three memory types, how to extract and consolidate knowledge, provenance tracking, and practical patterns for OAK CI's memory tools.
+
+---
+
+## Memory Types
+
+### Episodic Memory (What Happened)
+
+Records of specific events, experiences, and outcomes. Time-stamped, contextual, narrative — answers "what happened last time?"
+
+- Tied to a specific moment and context
+- Includes cause, effect, and resolution
+- Most valuable when recent; decays in relevance over time
+- Forms raw material for semantic memory through consolidation
+
+**Examples:**
+- "Refactoring broke auth tests — circular imports between `auth_service.py` and `user_service.py`"
+- "Customer API returned 429s after batch size increased to 100 — dropped to 50"
+
+**OAK CI mapping:** Observations with type `bug_fix` or `gotcha`
+
+### Procedural Memory (How To Do Things)
+
+Skills, workflows, and step-by-step processes. Relatively stable — changes slowly as best practices evolve.
+
+- Describes a sequence of actions to achieve a goal
+- Codified in documentation, runbooks, or constitutions
+- Most valuable when accurate and current
+
+**Examples:**
+- "To add a new API endpoint: create route, add service method, write tests, update docs"
+- "To add a new OAK feature: create manifest.yaml, implement RFC, add commands, register in feature service"
+
+**OAK CI mapping:** Constitutions (`oak/constitution.md`), skill files, golden paths. Procedural memory lives in structured documents rather than individual observations.
+
+### Semantic Memory (Facts and Concepts)
+
+General knowledge about the domain, codebase, or system. Context-independent — true regardless of when or how it was learned.
+
+- Factual, declarative knowledge
+- Stable until the underlying reality changes
+- Provides context without requiring the full history
+
+**Examples:**
+- "This project uses PostgreSQL 15 with read replicas for reporting queries"
+- "We chose event sourcing for the order system to support audit requirements"
+
+**OAK CI mapping:** Observations with type `discovery`, `decision`, or `trade_off`
+
+### Memory Type Selection Guide
+
+| You want to remember... | Memory Type | OAK CI Type |
+|---|---|---|
+| A bug you fixed and why | Episodic | `bug_fix` |
+| A non-obvious behavior | Episodic | `gotcha` |
+| How to deploy the app | Procedural | Constitution/Skill |
+| An architectural decision | Semantic | `decision` |
+| A pattern you discovered | Semantic | `discovery` |
+| A trade-off you accepted | Semantic | `trade_off` |
+
+**Rule of thumb:** If it happened once and the specifics matter, it is episodic. If it is always true (until something changes), it is semantic. If it describes how to do something, it is procedural.
+
+---
+
+## Memory Extraction Pipeline
+
+Raw experience becomes useful memory through four stages: capture, classify, consolidate, retrieve.
+
+### 1. Capture (During Work)
+
+Record observations as they happen — context and detail fade quickly. Capture surprising behavior, root causes (not symptoms), decisions with rationale, and codebase discoveries.
+
+```bash
+# Good — specific, includes file path and root cause
+oak ci remember "Auth middleware silently swallows ConnectionError — returns 200 instead of 503. Bare except on line 47" --type gotcha --context src/middleware/auth.py
+
+# Bad — vague, no actionable detail
+oak ci remember "Auth has a bug" --type gotcha
+```
+
+**Every observation should include:** what happened, where it applies (file paths), and why it matters.
+
+### 2. Classify
+
+Assign a type based on what kind of knowledge the observation represents.
+
+| Observation is about... | Classify as |
+|---|---|
+| Something that broke and how you fixed it | `bug_fix` |
+| A non-obvious behavior that could trip someone up | `gotcha` |
+| A fact about the system or domain | `discovery` |
+| A choice you made and why | `decision` |
+| A compromise with known downsides | `trade_off` |
+
+### 3. Consolidate
+
+Individual episodic memories should consolidate into semantic knowledge over time — specific events become general understanding.
+
+**Example:** Three separate gotchas about parallel test failures (shared session state, shared mock gateway, shared email queue) consolidate into one decision: "Integration tests using shared external state must use the `isolated_services` fixture."
+
+```bash
+# Create the consolidated observation
+oak ci remember "Integration tests with shared external state must use isolated_services fixture" --type decision --context tests/conftest.py
+
+# Resolve the observations it replaces
+oak ci resolve <uuid-1> --status superseded
+oak ci resolve <uuid-2> --status superseded
+```
+
+**When to consolidate:** Three or more observations about the same topic, or a pattern has emerged from individual incidents.
+
+### 4. Retrieve
+
+Pull relevant memories when starting new work.
+
+```bash
+# Automatic context assembly — curated code + memories based on task and files
+oak ci context "refactoring the auth service" -f src/services/auth.py
+
+# Targeted search by type
+oak ci search "auth import issues" --type memory
+oak ci search "rate limiting" --type all
+```
+
+---
+
+## Provenance Tracking
+
+Every memory should answer: who learned this, when, and from what evidence?
+
+### Why Provenance Matters
+
+Stale memories are worse than no memories — they actively mislead. An observation saying "the users table has no index on email" causes agents to work around a problem that was fixed last week. Provenance (when recorded, what code referenced) lets you detect and resolve staleness.
+
+### OAK CI Provenance Fields
+
+| Field | What it records |
+|---|---|
+| `session_id` | Which session created the observation |
+| `created_at_epoch` | When it was created (Unix timestamp) |
+| `context` | File path or additional context linking to code |
+| `session_origin_type` | Planning, investigation, or implementation |
+| `resolved_by_session_id` | Which session marked it resolved |
+| `resolved_at` | When it was resolved |
+
+### Provenance Best Practices
+
+**Include file paths in the context field.** Ties memory to code, enabling staleness detection when code changes.
+
+```bash
+# Good — tied to specific code
+oak ci remember "Rate limiter uses fixed window, not sliding — burst at window boundaries" --type discovery --context src/middleware/rate_limiter.py
+
+# Weak — floating, hard to verify later
+oak ci remember "Rate limiter has a burst problem" --type discovery
+```
+
+**Include error messages and specific details** for searchability. **Record session type** — implementation observations (tested and verified) carry more weight than planning observations (potentially speculative).
+
+---
+
+## Memory-as-a-Tool Pattern
+
+Instead of holding everything in the context window, treat memory as an external tool queried on demand.
+
+### The Workflow
+
+```
+Agent receives task -> searches memory -> gets relevant results -> uses in current work -> stores new learnings -> future sessions benefit
+```
+
+**Benefits:** Context window stays focused on the current task. Memory accumulates across sessions. Each retrieval is targeted. Knowledge persists beyond session boundaries and is shared across agents.
+
+### OAK CI Commands
+
+**Store** during work:
+```bash
+oak ci remember "Billing API rate limits at 100 req/min — returns 429 with Retry-After" --type discovery
+```
+
+**Retrieve** when starting work:
+```bash
+oak ci search "billing API rate limits" --type memory
+oak ci context "refactoring the auth service" -f src/services/auth.py
+```
+
+**Resolve** when memory becomes stale:
+```bash
+oak ci resolve <uuid> --reason "Refactored to eliminate circular dependency"
+oak ci resolve <uuid> --status superseded --reason "Replaced by event-driven architecture"
+```
+
+---
+
+## Session Memory Patterns
+
+### Session Summaries
+
+At session end, generate a summary: what was accomplished, what was learned, what remains. OAK CI stores these as `session_summary` observations, creating episodic memories for future sessions.
+
+**A good session summary includes:**
+- Tasks completed (with file paths)
+- Decisions made and their rationale
+- Open questions or unfinished work
+- Observations stored during the session
+
+### Cross-Session Context
+
+Retrieve relevant context from past sessions when starting new work:
+
+```bash
+oak ci context "continuing the auth refactor" -f src/services/auth.py -f src/services/user.py
+```
+
+This returns relevant memories (including past session summaries) alongside related code, providing continuity without full conversation history.
+
+### Memory Decay and Maintenance
+
+Not all memories stay relevant. Active maintenance prevents memory rot. Resolve observations when: the referenced code was refactored or deleted, the decision was reversed, the gotcha was fixed, or newer observations cover the same ground better.
+
+| Situation | Action |
+|---|---|
+| Bug was fixed | Resolve the `bug_fix` observation |
+| Gotcha no longer applies | Resolve the `gotcha` observation |
+| Decision was reversed | Mark `superseded`, create new decision |
+| Observations overlap | Consolidate into one, resolve the rest |
+| Code was deleted | Resolve related observations |
+
+---
+
+## Common Memory Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|---|---|---|
+| Storing everything | Bloat, poor retrieval — important observations buried in noise | Be selective: only store what would help a future session |
+| Vague observations | "Auth was broken" — useless for retrieval, no actionable guidance | Include specifics: error messages, file paths, root cause |
+| Never resolving | Stale memories mislead sessions into working around fixed problems | Resolve observations after addressing the issue |
+| No context field | Memory disconnected from code, cannot validate against current state | Always include file paths or module names |
+| Duplicate observations | Same insight stored multiple times degrades precision | Search before storing; consolidate duplicates |
+| Session-only memory | Knowledge lost when session ends | Use persistent memory for learnings worth keeping |
+| Over-consolidation | Premature generalization loses nuance from specific incidents | Wait for three or more instances before generalizing |
+| No provenance | Cannot assess validity; no way to trace back to evidence | Include file paths, timestamps, and specific details |

--- a/.codex/skills/context-engineering/references/prompt-foundations.md
+++ b/.codex/skills/context-engineering/references/prompt-foundations.md
@@ -1,0 +1,322 @@
+# Prompt Engineering Foundations
+
+Eight core techniques for writing effective prompts. Each section covers: what it is, when to use it, how to apply it, a concrete example, and common mistakes.
+
+---
+
+## 1. Be Clear and Direct
+
+Specificity eliminates ambiguity. Tell the model exactly what you want — format, length, style, and constraints.
+
+**How to apply:**
+- State the task, format, and constraints up front
+- Use imperative verbs: "List", "Analyze", "Write", "Compare"
+- Specify exclusions when they matter
+- Define success criteria
+
+**Example — bad vs good:**
+
+```
+Bad:  Review this code.
+
+Good: Review this Python function for:
+      1. Security vulnerabilities (injection, XSS)
+      2. Performance issues (N+1 queries, unnecessary allocations)
+      3. Correctness bugs (off-by-one, null handling)
+
+      For each issue: line number, severity (critical/warning/info),
+      and corrected code. If none found, say "None found."
+```
+
+**Mistakes:** Assuming the model infers format preferences. Using vague qualifiers ("good", "comprehensive") without defining them. Omitting constraints then being surprised by the output shape.
+
+---
+
+## 2. Use Examples (Multishot Prompting)
+
+Provide 3-5 input-output examples demonstrating the pattern you want. Examples are the most reliable way to specify format, tone, and edge case handling.
+
+**How to apply:**
+- 3-5 examples minimum (one or two won't establish a pattern)
+- Vary them: happy path, edge cases, boundary conditions, negative cases
+- Show exact input-output structure
+- Order simple to complex
+
+**Example:**
+
+```xml
+Classify each customer message into exactly one category.
+
+<examples>
+<example>
+<input>I can't log in even with the right password</input>
+<output>category: authentication | priority: high</output>
+</example>
+<example>
+<input>How much does the enterprise plan cost?</input>
+<output>category: billing | priority: low</output>
+</example>
+<example>
+<input>Your product crashed during my presentation!!!</input>
+<output>category: bug-report | priority: critical</output>
+</example>
+<example>
+<input></input>
+<output>category: invalid | priority: none</output>
+</example>
+</examples>
+
+Now classify: <input>{{MESSAGE}}</input>
+```
+
+The last example teaches the model how to handle malformed input rather than leaving it to guess.
+
+**Mistakes:** Only showing happy-path examples. Examples too similar to each other. Inconsistent formatting across examples (the model mirrors inconsistency).
+
+---
+
+## 3. Chain of Thought (CoT)
+
+Instruct the model to reason step by step before answering. Dramatically improves accuracy on logic, math, and multi-step analysis.
+
+**Three levels:**
+
+**Basic** — add "Think step by step." Simple, effective for straightforward reasoning.
+
+**Guided** — provide numbered steps when the reasoning process matters:
+```
+Determine if this function has a bug:
+1. Identify what it should do from name and docstring
+2. Trace logic with a normal input
+3. Trace with edge cases (empty, null, boundary)
+4. Compare actual vs expected behavior
+5. Conclude: bug or no bug, with evidence
+```
+
+**Structured** — wrap reasoning in tags to separate thinking from output:
+```xml
+Analyze whether this migration is safe for production.
+
+Work through your analysis inside <reasoning> tags, then give your
+verdict inside <verdict> tags. Consider: table locks, reversibility,
+data backfill volume, partial failure scenarios.
+```
+
+| Level | Use when |
+|---|---|
+| Basic | Simple math, single-step deductions |
+| Guided | Multi-step debugging, analysis where process matters |
+| Structured | Complex decisions, when downstream systems consume the reasoning |
+
+**Mistakes:** Using CoT for simple factual lookups (adds latency, no accuracy gain). Over-constraining the thinking format. Asking for "just the answer" on hard problems.
+
+---
+
+## 4. Use XML Tags for Structure
+
+Claude treats XML tags as first-class structural elements — the most reliable way to separate context, instructions, examples, and output format.
+
+**When to use:** Any prompt with more than one logical section, when mixing data with instructions, when specifying output format.
+
+**Example:**
+```xml
+<context>
+Debugging a failing test suite. Project: Python 3.12, pytest.
+</context>
+
+<test_output>
+FAILED test_auth.py::test_login_redirect - expected 302, got 200
+FAILED test_auth.py::test_expired_token - connection pool exhausted
+</test_output>
+
+<instructions>
+For each failure: identify root cause, determine if related, suggest fix.
+</instructions>
+
+<output_format>
+## [test name]
+**Root cause:** [one sentence]
+**Related:** [yes/no and why]
+**Fix:** [code block]
+</output_format>
+```
+
+**Nesting** for hierarchy (two levels is usually sufficient):
+```xml
+<documents>
+  <document id="1" title="API Spec">...content...</document>
+  <document id="2" title="Error Logs">...content...</document>
+</documents>
+```
+
+**Mistakes:** Generic tag names (`<data>`) instead of specific ones (`<error_log>`). Over-nesting beyond two levels. Mixing XML tags with markdown headers for the same purpose.
+
+---
+
+## 5. Give Claude a Role (System Prompts)
+
+The system prompt establishes persistent behavioral context — role, constraints, and output conventions that frame every response.
+
+**How to apply:**
+- Define role, expertise, and boundaries
+- Set the right altitude: specific enough to be useful, general enough for varied inputs
+- Include what to do when uncertain
+
+**Example — bad vs good:**
+
+```
+Bad:  You are a helpful coding assistant. Be thorough and accurate.
+```
+"Helpful" and "thorough" are not actionable — they contain no specific guidance.
+
+```xml
+Good:
+<role>
+Senior backend engineer. Python + PostgreSQL.
+Production system handling financial transactions.
+</role>
+
+<constraints>
+- Never sacrifice data consistency for performance
+- Flag non-idempotent operations
+- When unsure, say "I'm not confident because..." rather than guessing
+</constraints>
+
+<output_conventions>
+- Python type hints in all code examples
+- Include error handling (no happy-path-only code)
+- Reference specific line numbers when reviewing
+</output_conventions>
+```
+
+**Mistakes:** System prompt so long it dilutes the important parts. Only negative instructions ("don't do X") without positive guidance. Role too narrow, causing refusals on legitimate requests.
+
+---
+
+## 6. Chain Complex Prompts
+
+Break complex tasks into sequential steps where output of step N feeds step N+1. Better results than asking for everything at once.
+
+**When to use:** Tasks with distinct phases (research, analyze, synthesize). When quality at each step matters. When different steps need different instructions.
+
+**Example pipeline:**
+```
+Step 1 (Extract):  "Extract all function signatures and docstrings."
+Step 2 (Analyze):  "For each function, identify missing error handling,
+                    unused params, unclear naming. Rate severity."
+Step 3 (Synthesize): "Group by severity. Write corrected code for
+                      critical/warning issues. Summarize in a table."
+```
+
+**Gate outputs between steps** — validate before passing forward:
+```python
+extracted = call_model(step_1_prompt, document)
+
+# Gate: verify extraction produced results
+if not extracted.functions:
+    raise ValueError("Extraction empty — check input format")
+
+analysis = call_model(step_2_prompt, extracted)
+```
+
+**Mistakes:** Passing too much context between steps (carry only what the next step needs). Not validating intermediates. Steps too granular (each should do meaningful work).
+
+---
+
+## 7. Long Context Window Tips
+
+Position and organization of information in the context window significantly affects output quality. The "lost in the middle" effect means information buried in the center of very long contexts gets less attention.
+
+**Key techniques:**
+
+**Front-load and repeat critical instructions:**
+```xml
+<instructions>
+<!-- FIRST: anchor behavior -->
+Find all security vulnerabilities. Focus on injection, auth bypass, data exposure.
+</instructions>
+
+<codebase>
+...thousands of lines...
+</codebase>
+
+<reminder>
+<!-- LAST: reinforce -->
+Focus only on security vulnerabilities.
+Format: file, line, type, severity, fix.
+</reminder>
+```
+
+**Tag-delineate sections** when including multiple documents:
+```xml
+<documents>
+  <document title="Auth Module" path="src/auth.py">...code...</document>
+  <document title="Schema" path="schema.sql">...schema...</document>
+</documents>
+```
+
+**Include retrieval hints** for very long contexts: "Find the users table in the Schema document and check for a unique constraint on email."
+
+**Order by relevance:** most relevant documents first. For bug analysis: error/stack trace, then source file, then config, then tests, then docs.
+
+**Mistakes:** Dumping context without structure. Critical instructions only in the middle. Including irrelevant context "just in case" (dilutes attention).
+
+---
+
+## 8. Extended Thinking
+
+Extended thinking allocates dedicated tokens for the model to reason internally before producing a visible response. Unlike CoT, this happens in a separate, larger thinking space and can use significantly more tokens.
+
+**When to use:**
+- Complex math or proofs
+- Multi-file code analysis with component interactions
+- Architecture decisions with many tradeoffs
+- Debugging where root cause is non-obvious
+
+**When NOT to use:** Simple factual questions, straightforward code generation, tasks where speed matters more than depth.
+
+**How to apply:**
+
+Set thinking budget based on complexity: small for simple debugging, large for architecture review or multi-step planning.
+
+Let the model reason freely — don't constrain thinking format:
+```
+Good: "Analyze this distributed system for consistency issues.
+       Think deeply about edge cases before responding."
+
+Bad:  "In your thinking, first list all components, then draw
+       arrows between them, then..."
+```
+
+Specify what to *produce*, not how to *think*. Combine with structured output:
+```xml
+<task>
+Review this migration plan. Consider data integrity, rollback safety,
+and performance impact on a 50M-row table.
+</task>
+
+<output_format>
+1. GO / NO-GO recommendation
+2. Risk summary (one paragraph)
+3. Required changes before deploy (bulleted list)
+</output_format>
+```
+
+**Mistakes:** Enabling for every prompt (wastes tokens on simple tasks). Controlling the thinking format. Using thinking as substitute for providing good context.
+
+---
+
+## Anti-Patterns Reference
+
+| Anti-Pattern | Why It Fails | Fix |
+|---|---|---|
+| "Be helpful" | Too vague, no actionable guidance | Specify exact behavior, constraints, output format |
+| Contradictory instructions | Model picks one unpredictably | Resolve conflicts; prioritize with "IMPORTANT" |
+| Wall of text prompt | Key info buried, position bias | Structure with XML; front-load critical info |
+| No examples | Model guesses output format | Add 3-5 diverse multishot examples |
+| "Do everything at once" | Exceeds single-prompt capacity | Chain into sequential steps with gates |
+| Overly rigid templates | Brittle to edge cases | Define principles and show examples instead |
+| "Don't do X" (only negatives) | Model attention anchors on X | State what TO do instead |
+| Expecting one-shot perfection | Unrealistic for complex tasks | Iterate: test varied inputs, refine on failures |
+| Kitchen-sink system prompt | Dilutes important instructions | Keep focused: role, constraints, output conventions |
+| No output validation | Hallucinations and drift undetected | Validate between chained steps |

--- a/.codex/skills/context-engineering/references/system-prompt-design.md
+++ b/.codex/skills/context-engineering/references/system-prompt-design.md
@@ -1,0 +1,237 @@
+# System Prompt Design
+
+System prompts define who the model is, what it should do, and how it should behave. This reference covers effective system prompt anatomy, writing instructions at the right abstraction level, Claude-specific patterns, and annotated templates.
+
+---
+
+## System Prompt Anatomy
+
+Every effective system prompt has five components, in this order. Ordering matters — models give more weight to content that appears earlier.
+
+### 1. Role and Identity
+
+One or two sentences establishing domain expertise. Sets tone, vocabulary, and decision-making framework.
+
+```
+You are a senior backend engineer specializing in distributed systems.
+```
+
+Be specific enough to shape behavior, broad enough to handle varied inputs. Avoid character fiction ("Dr. Sarah Chen, known for dry wit") — it dilutes technical focus. Avoid generics ("You are a helpful assistant") — it changes nothing.
+
+### 2. Core Constraints
+
+Hard rules the model must always follow. Put these BEFORE task instructions — models respect early constraints more reliably. Use RFC 2119 language (MUST, MUST NOT, SHOULD, MAY) for clarity.
+
+```xml
+<constraints>
+- You MUST NOT modify database schema without explicit approval
+- You MUST cite specific file and line numbers when identifying issues
+- You SHOULD prefer backward-compatible solutions
+- When uncertain, ask for clarification rather than guessing
+</constraints>
+```
+
+The last line is critical — every system prompt should define what the model does when unsure. Without it, the model either guesses (risky) or refuses (unhelpful).
+
+### 3. Task Instructions
+
+What the model should do. Write at the right "altitude" — principles over procedures (see the Altitude Scale below).
+
+```xml
+<instructions>
+When reviewing code, focus on correctness and security over style.
+Flag potential issues but do not rewrite working code for aesthetic reasons.
+When multiple approaches exist, explain the tradeoffs and recommend one.
+</instructions>
+```
+
+Good task instructions answer: What is the primary objective? What gets prioritized when objectives conflict? What does "done" look like?
+
+### 4. Output Format
+
+Be explicit — the model won't consistently infer format preferences.
+
+```xml
+<output_format>
+Respond with a JSON object:
+{
+  "summary": "One-sentence assessment",
+  "issues": [{"severity": "critical|warning|info", "file": "path", "line": 42, "description": "...", "suggestion": "..."}],
+  "overall_rating": "approve | request-changes | needs-discussion"
+}
+</output_format>
+```
+
+If you want markdown, say so. If you want JSON, provide the schema. Ambiguity here is the most common source of format drift.
+
+### 5. Canonical Examples
+
+Two to three input-output pairs demonstrating ideal behavior. Examples anchor behavior more reliably than instructions alone. Show range (positive and negative cases) and edge cases.
+
+```xml
+<example>
+<input>
+def get_user(id):
+    query = f"SELECT * FROM users WHERE id = {id}"
+    return db.execute(query)
+</input>
+<output>
+**Critical: SQL Injection** — line 2 uses f-string with user input.
+Fix: `db.execute("SELECT * FROM users WHERE id = ?", [id])`
+</output>
+</example>
+```
+
+---
+
+## The Altitude Scale
+
+The most common system prompt mistake is writing instructions at the wrong abstraction level.
+
+### Level 1: Ground Level (Too Specific)
+
+```
+Always use 4-space indentation. Variable names must be camelCase.
+Functions must not exceed 20 lines.
+```
+
+Brittle. Doesn't adapt to context. What happens when the codebase uses tabs?
+
+### Level 2: Cruising Altitude (Right Level)
+
+```
+Follow the project's established conventions. Match surrounding
+code style. Prefer clarity over cleverness.
+```
+
+Principled, adaptable. Handles novel situations because it has principles, not just rules.
+
+### Level 3: Stratosphere (Too Vague)
+
+```
+Write good code. Be helpful. Follow best practices.
+```
+
+No actionable guidance. The model falls back to generic behavior.
+
+### Finding Your Altitude
+
+| Domain | Too Low | Right Altitude | Too High |
+|---|---|---|---|
+| Code Review | "Flag if cyclomatic complexity > 10" | "Flag functions hard to understand at a glance" | "Review the code" |
+| Writing | "Sentences must be 12-15 words" | "Write concisely. Prefer short sentences. Cut filler." | "Write well" |
+| Data Analysis | "Use pandas groupby then merge" | "Use efficient operations. Profile before optimizing." | "Analyze the data" |
+| Security Audit | "Check for CVE-2024-1234" | "Identify injection points and trust boundaries" | "Find vulnerabilities" |
+
+**The test:** If your instruction applies regardless of language, framework, or codebase, it's the right altitude.
+
+---
+
+## Claude-Specific Patterns
+
+### XML Tag Conventions
+
+Claude has strong native understanding of XML structure:
+
+- `<context>`, `<instructions>`, `<constraints>`, `<examples>` for top-level sections
+- Nesting up to 2-3 levels: `<examples><example><input>...</input><output>...</output></example></examples>`
+- Attributes for metadata: `<document id="1" title="API Spec" path="src/api.py">`
+- Descriptive tag names — `<error_log>` over `<data>`, `<user_request>` over `<input>`
+- No `<system>` wrapper needed — Claude already knows it's reading a system prompt
+
+### Extended Thinking Integration
+
+Guide the model toward deeper reasoning without constraining its process. Say "Think deeply about edge cases before responding" (good) rather than "First list all components, then draw arrows, then rate each on a 1-5 scale" (bad). Specify what to produce, not how to think.
+
+### Prefilling
+
+Start the assistant's response to anchor output format:
+
+```
+Assistant: {"analysis":
+```
+
+Useful for ensuring JSON output, anchoring structure, or preventing preamble ("Sure! Here's my analysis..."). Use prefilling for format, not for constraining reasoning.
+
+---
+
+## Annotated Templates
+
+### Code Review Agent
+
+```xml
+You are a senior software engineer performing code review.
+
+<constraints>
+- Focus on correctness, security, and maintainability
+- Do NOT rewrite working code for style preferences alone
+- Flag potential bugs with severity: critical, warning, info
+- If uncertain whether something is a bug, say so explicitly
+- MUST NOT approve code with known security vulnerabilities
+</constraints>
+
+<instructions>
+Review the provided code changes. For each issue:
+1. Identify the file and line
+2. Describe the issue and why it matters
+3. Suggest a fix
+
+After reviewing, provide a summary assessment.
+If no issues are found, say so — do not fabricate issues.
+</instructions>
+```
+
+Constraints before instructions, "do not fabricate" prevents false positives, severity levels in constraints keep output consistent.
+
+### Research Assistant
+
+```xml
+You are a research assistant analyzing documents and synthesizing findings.
+
+<constraints>
+- Cite sources with specific quotes or page references
+- Distinguish facts in documents from your inferences
+- If asked about something not in the documents, say so clearly
+- MUST NOT fabricate citations or references
+</constraints>
+
+<instructions>
+Analyze provided documents: identify themes, note contradictions between
+sources, synthesize findings. Use <finding> tags with source attribution.
+</instructions>
+
+<output_format>
+<finding source="Document Title, p. X">
+[Insight with direct quote or specific reference]
+</finding>
+</output_format>
+```
+
+MUST NOT on fabricated citations addresses the highest-risk failure mode. Distinguishing facts from inferences prevents the model from presenting reasoning as source material.
+
+### Data Analysis Agent
+
+```xml
+You are a data analyst working with structured datasets.
+
+<constraints>
+- Show methodology before results
+- Validate data quality before analysis (nulls, duplicates, outliers)
+- State assumptions explicitly
+- Do not over-interpret small samples (note when n < 30)
+</constraints>
+
+<instructions>
+For each analysis: understand the question, examine data quality,
+choose and explain the method, present findings with caveats.
+Prefer tables over prose for numerical results.
+</instructions>
+```
+
+Methodology-before-results prevents jumping to conclusions. Concrete threshold (n < 30) instead of vague "be careful."
+
+---
+
+## Cross-Reference
+
+See also: The `/project-governance` skill for creating and maintaining project constitutions and agent rules files — these are system prompts implemented as version-controlled documents.

--- a/.codex/skills/project-governance/SKILL.md
+++ b/.codex/skills/project-governance/SKILL.md
@@ -68,6 +68,7 @@ oak rules detect-existing      # Discover all configured agent instruction files
 - **Creating CLAUDE.md, AGENTS.md, or .cursorrules** for a new project
 - **Proposing a new feature** that needs team review (RFC)
 - **Making architectural decisions** that should be documented (ADR)
+- **Learning context engineering theory** behind effective rule writing -- see `/context-engineering` for the altitude concept, canonical examples, and structured context patterns
 - **Reviewing an RFC** for completeness and technical soundness
 
 ## Constitution Structure

--- a/.cursor/skills/codebase-intelligence/SKILL.md
+++ b/.cursor/skills/codebase-intelligence/SKILL.md
@@ -124,7 +124,7 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "YOUR QUERY HERE"
 | Table | Purpose | Key Columns |
 |-------|---------|-------------|
 | `memory_observations` | Extracted memories/learnings | `observation`, `memory_type`, `status`, `context`, `tags`, `importance`, `session_origin_type` |
-| `sessions` | Coding sessions (launch to exit) | `id`, `agent`, `status`, `summary`, `title`, `started_at`, `created_at_epoch` |
+| `sessions` | Coding sessions (launch to exit) | `id`, `agent`, `status`, `summary`, `title`, `title_manually_edited`, `started_at`, `created_at_epoch` |
 | `prompt_batches` | User prompts within sessions | `session_id`, `user_prompt`, `classification`, `response_summary` |
 | `activities` | Raw tool executions | `session_id`, `tool_name`, `file_path`, `success`, `error_message` |
 | `agent_runs` | CI agent executions | `agent_name`, `task`, `status`, `result`, `cost_usd`, `turns_used` |

--- a/.cursor/skills/codebase-intelligence/SKILL.md
+++ b/.cursor/skills/codebase-intelligence/SKILL.md
@@ -130,7 +130,7 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "YOUR QUERY HERE"
 | `agent_runs` | CI agent executions | `agent_name`, `task`, `status`, `result`, `cost_usd`, `turns_used` |
 | `session_link_events` | Session linking analytics | `session_id`, `event_type`, `old_parent_id`, `new_parent_id` |
 | `session_relationships` | Semantic session relationships | `session_a_id`, `session_b_id`, `relationship_type`, `similarity_score` |
-| `agent_schedules` | Cron scheduling state | `task_name`, `cron_expression`, `enabled`, `last_run_at`, `next_run_at` |
+| `agent_schedules` | Cron scheduling state | `task_name`, `cron_expression`, `enabled`, `additional_prompt`, `last_run_at`, `next_run_at` |
 | `resolution_events` | Cross-machine resolution propagation | `observation_id`, `action`, `source_machine_id`, `applied`, `content_hash` |
 <!-- END GENERATED CORE TABLES -->
 

--- a/.cursor/skills/codebase-intelligence/references/schema.md
+++ b/.cursor/skills/codebase-intelligence/references/schema.md
@@ -2,7 +2,7 @@
 
 Complete DDL for the Oak CI SQLite database at `.oak/ci/activities.db`.
 
-Current schema version: **4**
+Current schema version: **6**
 
 ## memory_observations
 
@@ -53,11 +53,14 @@ CREATE TABLE IF NOT EXISTS sessions (
     processed BOOLEAN DEFAULT FALSE,  -- Has background processor handled this?
     summary TEXT,  -- LLM-generated session summary
     title TEXT,  -- LLM-generated short session title (10-20 words)
+    title_manually_edited BOOLEAN DEFAULT FALSE,  -- Protect manual edits from LLM overwrite
     created_at_epoch INTEGER NOT NULL,
     parent_session_id TEXT,  -- Session this was derived from
     parent_session_reason TEXT,  -- Why linked: 'clear', 'compact', 'inferred'
     source_machine_id TEXT,  -- Machine that originated this record
-    transcript_path TEXT  -- Path to session transcript file for recovery
+    transcript_path TEXT,  -- Path to session transcript file for recovery
+    summary_updated_at INTEGER,  -- Epoch when summary was last generated/updated
+    summary_embedded INTEGER DEFAULT 0  -- Has summary been indexed in ChromaDB?
 );
 ```
 

--- a/.cursor/skills/codebase-intelligence/references/schema.md
+++ b/.cursor/skills/codebase-intelligence/references/schema.md
@@ -2,7 +2,7 @@
 
 Complete DDL for the Oak CI SQLite database at `.oak/ci/activities.db`.
 
-Current schema version: **3**
+Current schema version: **4**
 
 ## memory_observations
 
@@ -228,6 +228,7 @@ CREATE TABLE IF NOT EXISTS agent_schedules (
     cron_expression TEXT,           -- Cron expression (e.g., '0 0 * * MON')
     description TEXT,               -- Human-readable schedule description
     trigger_type TEXT DEFAULT 'cron', -- 'cron' or 'manual' (future: 'git_commit', 'file_change')
+    additional_prompt TEXT,          -- Persistent assignment prepended to task on each run
 
     -- Runtime state
     last_run_at TEXT,

--- a/.cursor/skills/context-engineering/SKILL.md
+++ b/.cursor/skills/context-engineering/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: context-engineering
+description: >-
+  Design effective prompts and optimize context for AI models and agents.
+  Covers prompt engineering foundations (clarity, examples, chain of thought,
+  XML structure), the four context engineering strategies (Write, Select,
+  Compress, Isolate), agent memory and session patterns, and before/after
+  examples showing measurable improvement. Use when writing system prompts,
+  designing agent workflows, optimizing context windows, building prompt
+  templates, structuring few-shot examples, reducing context rot, or
+  improving AI output quality.
+allowed-tools: Read
+user-invocable: true
+---
+
+# Context Engineering
+
+Design effective prompts and optimize the full context window for AI models and agents to produce consistently high-quality output.
+
+## Quick Start
+
+### Recipe 1: Improve a vague prompt
+
+**Before:** `Review this code and give feedback.`
+
+**After:**
+```xml
+<task>Review the provided code for correctness, performance, and maintainability.</task>
+<output-format>
+For each issue: file/line, severity (critical|warning|suggestion), problem (one sentence), fix (concrete code change).
+If no issues, state "No issues found" and list one strength.
+</output-format>
+<code>{{code_to_review}}</code>
+```
+
+**Why it works:** Specifies evaluation criteria, defines output structure, separates instructions from data with XML tags.
+
+### Recipe 2: Design a system prompt
+
+Use the **altitude concept** -- not so high it's useless ("be helpful"), not so low it's brittle ("always use 4 spaces").
+
+1. **Define the role** in one sentence: what the agent IS and IS NOT
+2. **Set altitude** -- right level: "Follow the project's existing naming conventions. When none exists, prefer descriptive names over short ones."
+3. **Add constraints** using RFC 2119 language (MUST, SHOULD, MAY)
+4. **Include 1-2 canonical examples** of ideal output
+5. **Define non-goals** to prevent scope creep
+
+See `references/system-prompt-design.md` for full anatomy and templates.
+
+### Recipe 3: Structure agent context with the 4 strategies
+
+When your agent produces inconsistent or degraded output, apply the four strategies:
+
+| Strategy | Action | Example |
+|----------|--------|---------|
+| **Write** | Craft persistent instructions | System prompt with altitude-appropriate rules |
+| **Select** | Choose what enters context | Use `oak_search` to retrieve only relevant code |
+| **Compress** | Reduce tokens, preserve signal | Summarize prior conversation turns, delegate to sub-agents |
+| **Isolate** | Move information out of context | Store reference docs externally, load just-in-time |
+
+```
+1. Start with Write: define a clear system prompt
+2. Apply Select: give the agent only the tools and context it needs
+3. Add Compress: implement compaction for long sessions
+4. Use Isolate: move large reference material behind retrieval
+```
+
+See `references/context-engineering-framework.md` for the full framework.
+
+## The Evolution: Prompt to Context Engineering
+
+| Level | Focus | Scope | Key Insight |
+|-------|-------|-------|-------------|
+| **Basic Prompting** | The question you type | Single user message | Clarity matters |
+| **Prompt Engineering** | Crafting effective prompts | Prompt + examples + structure | Technique amplifies quality |
+| **Context Engineering** | Everything the model sees | System prompt + tools + memory + retrieved docs + conversation history | The context window IS the product |
+
+Context engineering manages **everything** the model sees -- system prompt, tools, retrieved documents, conversation history, and memory. Every token either helps or hurts. The entire context window is a design surface.
+
+## Prompt Engineering Foundations
+
+These eight techniques form the foundation. Master them before moving to context engineering.
+
+| # | Technique | When to Use | Key Rule |
+|---|-----------|-------------|----------|
+| 1 | **Be clear and direct** | Always -- this is the baseline | State exactly what you want; remove ambiguity |
+| 2 | **Use examples (multishot)** | Output format matters, or the task is nuanced | Show 2-3 examples of ideal input/output pairs |
+| 3 | **Chain of thought** | Reasoning, math, multi-step logic | Ask the model to think step-by-step before answering |
+| 4 | **Use XML tags** | Separating instructions from data, structured output | Wrap distinct sections in descriptive tags like `<context>`, `<instructions>` |
+| 5 | **Give Claude a role** | Specialized tasks needing domain expertise | Set the role in the system prompt, not the user message |
+| 6 | **Chain complex prompts** | Multi-step workflows, pipelines | Break into sequential steps; output of step N feeds step N+1 |
+| 7 | **Long context tips** | Large documents, many files | Put key instructions at top and bottom; use XML to delineate sections |
+| 8 | **Extended thinking** | Complex reasoning, planning, self-correction | Enable thinking to let the model plan before responding |
+
+**Combining techniques:** Most effective prompts use 3-5 techniques together. A code review prompt might combine clarity (#1), XML structure (#4), role (#5), and examples (#2).
+
+See `references/prompt-foundations.md` for detailed explanations, examples, and anti-patterns for each technique.
+
+## Context Engineering Framework (4 Strategies)
+
+### Write: Craft the persistent context
+
+The Write strategy covers everything you author in advance: system prompts, tool descriptions, and instruction files. This is the context you control completely.
+
+**The altitude concept** is the most important principle. Your instructions need to be at the right level of abstraction:
+
+| Altitude | Example | Problem |
+|----------|---------|---------|
+| Too high | "Write clean code" | No actionable guidance -- the agent fills in its own interpretation |
+| Too low | "Always use `Array.prototype.reduce` for aggregation" | Brittle -- breaks when context changes, prevents good judgment |
+| Right | "Prefer declarative patterns over imperative loops. Choose the array method that most clearly expresses intent." | Guides without constraining |
+
+**Canonical examples** are powerful -- a single well-chosen example communicates more than paragraphs of rules:
+
+```xml
+<system>
+You generate API documentation from source code.
+<example>
+<input>
+def calculate_tax(amount: float, rate: float = 0.08) -> float:
+    """Calculate sales tax for a given amount."""
+    return round(amount * rate, 2)
+</input>
+<output>
+### `calculate_tax(amount, rate=0.08)`
+Calculate sales tax for a given amount.
+- `amount` (float): The pre-tax amount
+- `rate` (float, optional): Tax rate as decimal. Default: 0.08
+- **Returns:** float -- Tax amount, rounded to 2 decimal places.
+</output>
+</example>
+</system>
+```
+
+**Project-level Write strategy:** Use the `/project-governance` skill to create a constitution (`oak/constitution.md`) and agent instruction files. Your constitution IS your project-level system prompt. The altitude concept applies directly: "write good code" is useless; "copy `src/features/auth/service.py` for new services" is actionable.
+
+See `references/context-engineering-framework.md` for the full Write strategy guide.
+
+### Select: Choose what enters the context window
+
+Select the right information to include; keep everything else out.
+
+**For tools:** Provide the **minimal viable toolset** (unused tools cause confusion), write **unambiguous descriptions** (the model uses these to decide when to call), and prefer **specific tools** over general-purpose ones.
+
+**For retrieved context:** Quality over quantity (3 relevant snippets beat 20 loose ones), recency matters, and always include source attribution (file paths, line numbers).
+
+**Anti-pattern -- context stuffing:**
+```
+# Bad: dumping everything "just in case"
+context = all_docs + all_code + all_history + all_memories
+# Good: selecting what's relevant
+context = search_relevant_code(task) + get_recent_decisions(task)
+```
+
+### Compress: Reduce tokens while preserving information
+
+Compress rather than truncate. Preserve signal while reducing cost.
+
+**Strategies:** Conversation summarization (replace old turns with structured summary), note-taking scratchpad (running notes vs. re-reading history), sub-agent delegation (offload research, return only findings), and tool result cleanup (extract then clear verbose output).
+
+**When to compress:** Context exceeds 50% capacity, agent forgets earlier instructions, responses repeat or lose focus, or tool results contain mostly irrelevant data.
+
+### Isolate: Move information out of the main context
+
+Store information externally and load just-in-time, rather than keeping it in context at all times.
+
+**Patterns:** Just-in-time retrieval (load docs only when needed), progressive disclosure (summary first, details on demand), hybrid context loading (rules in system prompt, reference material behind search), and memory-as-a-tool (store externally, retrieve on demand).
+
+**Progressive disclosure example:** Agent sees summary ("Auth uses JWT") -> needs details (retrieves auth docs) -> needs code (retrieves auth service file). Each step loads only what's needed.
+
+See `references/context-engineering-framework.md` for the complete framework with extended examples.
+
+## Agent Context Patterns
+
+### Sessions vs memory
+
+| Concept | Scope | Lifetime | Purpose |
+|---------|-------|----------|---------|
+| **Session** | Single conversation | Ephemeral | Working memory for the current task |
+| **Memory** | Cross-session | Persistent | Accumulated knowledge and learnings |
+
+The common mistake: keeping everything in the session instead of writing important things to persistent memory.
+
+### Context rot
+
+Output quality degrades as conversations grow longer due to: **dilution** (instructions buried under tool results), **position bias** (models attend more to beginning/end, losing middle), **contradiction accumulation**, and **working memory overflow**.
+
+**Signs:** Agent forgets earlier constraints, responses become generic/repetitive, re-asks answered questions, quality drops vs. early turns.
+
+**Mitigation:** Apply Compress (summarize and compact) and Isolate (move reference material behind retrieval). For long-running agents, implement periodic compaction checkpoints.
+
+### Memory types
+
+| Type | What It Stores | Example | OAK CI Tool |
+|------|---------------|---------|-------------|
+| **Episodic** | What happened | "Refactored auth module in session #42" | `oak_search --type memory` |
+| **Procedural** | How to do things | "To add a feature, copy the strategic_planning exemplar" | `oak_remember` with type `discovery` |
+| **Semantic** | Facts and concepts | "The API uses JWT tokens with 1-hour expiry" | `oak_remember` with type `discovery` |
+
+### Memory-as-a-tool pattern
+
+Store externally, retrieve on demand -- instead of accumulating in context:
+
+```
+1. Discover → oak_remember("auth tokens expire after 1 hour", type="discovery")
+2. Later   → oak_search("auth token expiry") retrieves just-in-time
+3. Stale   → oak_resolve_memory(id, status="resolved") cleans up
+```
+
+This implements both Compress (don't hold everything) and Isolate (retrieve when needed).
+
+### Compaction strategies
+
+| Strategy | How It Works | Best For |
+|----------|-------------|----------|
+| **Last-N** | Keep only the last N conversation turns | Simple, predictable token budget |
+| **Recursive summarization** | Summarize old turns, keep recent ones verbatim | Long conversations with important early context |
+| **Hybrid** | Summarize + keep pinned messages (system prompt, key decisions) | Complex agents with critical persistent instructions |
+
+See `references/agent-context-patterns.md` and `references/memory-and-sessions.md` for detailed patterns and implementation guidance.
+
+## CI Integration: Context Engineering in Practice
+
+OAK's Codebase Intelligence tools directly implement the four context engineering strategies:
+
+| Strategy | CI Tool | What It Does |
+|----------|---------|--------------|
+| **Write** | `oak_remember` / `oak ci remember` | Persist learnings, decisions, and gotchas to long-term memory |
+| **Select** | `oak_search` / `oak ci search` | Retrieve only the code and memories relevant to the current task |
+| **Isolate** | `oak_context` / `oak ci context` | Assemble just-in-time context for a specific task, pulling from code and memory |
+| **Consolidate** | `oak_resolve_memory` / `oak ci resolve` | Resolve stale observations to prevent context rot in the memory store |
+
+### Example workflow
+
+```bash
+# WRITE: Store a discovery for future sessions
+oak ci remember "Payment service retries 3x with exponential backoff" --type discovery
+# SELECT: Find relevant code for a task
+oak ci search "payment retry logic" --type code -n 5
+# ISOLATE: Assemble just-in-time context
+oak ci context "fix payment timeout bug" -f src/services/payment.py
+# CONSOLIDATE: Clean up after fixing
+oak ci resolve <memory-id>
+```
+
+## Before/After Gallery
+
+### Vague prompt to structured prompt
+
+**Before:** `Write tests for the user service.`
+
+**After:**
+```xml
+<task>Write unit tests for UserService: create_user, get_user_by_email, delete_user.</task>
+<constraints>
+- pytest with fixtures for setup/teardown
+- Test success and error paths for each method
+- Mock external API calls (email verification)
+- Descriptive test names: test_create_user_with_duplicate_email_raises_conflict
+</constraints>
+```
+
+### Bloated system prompt to altitude-optimized
+
+**Before** (micromanaging): "Always use f-strings. Always use pathlib. Always use type hints. Use black with line length 88. Use dataclasses for DTOs. Never use print()..."
+
+**After** (right altitude):
+```xml
+<role>You are a Python developer working in this project.</role>
+<principles>
+- Follow existing patterns. Find the closest implementation and mirror its style.
+- Prefer modern Python (3.10+). When in doubt, check what the codebase uses.
+- Write code that reads clearly without comments. Comment only non-obvious "why" decisions.
+</principles>
+<quality>Run `make check` before considering any change complete.</quality>
+```
+
+### Context-stuffed agent to compress + isolate
+
+**Before:** 40,000 tokens (2K rules + 3K README + 8K tool descriptions + 12K API docs + 15K conversation = half irrelevant)
+
+**After:** 8,000 tokens (800 altitude-optimized prompt + 1,200 for 5 relevant tools + 2,000 retrieved context + 4,000 compressed conversation = all relevant)
+
+See `references/before-after-examples.md` for the full gallery with additional transformations.
+
+## When to Use What
+
+| Situation | Strategy | Key Technique | Reference |
+|-----------|----------|---------------|-----------|
+| Writing a new system prompt | Write | Altitude concept, canonical examples | `references/system-prompt-design.md` |
+| Prompt gives inconsistent results | Foundations | Add examples, use XML structure | `references/prompt-foundations.md` |
+| Agent losing track of goals | Compress | Conversation summarization, compaction | `references/context-engineering-framework.md` |
+| Agent context window filling up | Isolate | Just-in-time retrieval, progressive disclosure | `references/agent-context-patterns.md` |
+| Agent forgetting earlier decisions | Write + Compress | Pin critical context, summarize history | `references/memory-and-sessions.md` |
+| Need to measure prompt quality | Evaluate | A/B testing, rubric scoring | `references/evaluation-and-testing.md` |
+| Setting project-wide AI rules | Write | Constitution as system prompt | `/project-governance` skill |
+| Agent repeating mistakes across sessions | Write | Memory-as-a-tool, `oak_remember` | `references/memory-and-sessions.md` |
+| Complex multi-step reasoning | Foundations | Chain of thought, extended thinking | `references/prompt-foundations.md` |
+| Output format is wrong | Foundations | Examples (multishot), XML tags | `references/prompt-foundations.md` |
+
+## Deep Dives
+
+For detailed guidance on specific topics, consult the reference documents:
+
+- **`references/prompt-foundations.md`** -- Core prompt engineering techniques with examples and anti-patterns
+- **`references/context-engineering-framework.md`** -- The four strategies (Write, Select, Compress, Isolate) in depth
+- **`references/agent-context-patterns.md`** -- Sessions, memory types, context rot, and compaction strategies
+- **`references/system-prompt-design.md`** -- System prompt anatomy, the altitude concept, and reusable templates
+- **`references/memory-and-sessions.md`** -- Memory types, the memory-as-a-tool pattern, and OAK CI integration
+- **`references/before-after-examples.md`** -- Extended gallery of prompt and context transformations
+- **`references/evaluation-and-testing.md`** -- Measuring prompt quality, A/B testing, and iterative improvement

--- a/.cursor/skills/context-engineering/references/agent-context-patterns.md
+++ b/.cursor/skills/context-engineering/references/agent-context-patterns.md
@@ -1,0 +1,508 @@
+# Agent Context Patterns
+
+Context management patterns for AI agents: autonomous systems that take actions over multiple turns, read and write files, call tools, and maintain state across interactions. These patterns draw from Google's "Context Engineering: Sessions & Memory" whitepaper by Kimberly Milam & Antonio Gulli, and from production agent architectures.
+
+---
+
+## Sessions vs Memory
+
+Sessions and memory serve fundamentally different roles in agent context. Conflating them leads to either bloated sessions (stuffing everything into the conversation) or amnesia (losing hard-won knowledge between conversations).
+
+| Concept | Sessions | Memory |
+|---|---|---|
+| Lifetime | Single conversation | Across conversations |
+| Scope | Turn-by-turn interaction | Persistent knowledge |
+| Storage | Conversation history (in-context) | External database or file store |
+| Growth | Linear with turns | Curated, relatively stable |
+| Example | Chat messages, tool results | Learned preferences, past decisions, gotchas |
+
+### Session Architecture
+
+Each session is one continuous interaction with a goal. The session context grows with every turn: user message, assistant response, tool calls and their results.
+
+A well-structured session has three phases:
+
+1. **Start**: Goal is established, relevant context is loaded (system prompt, retrieved memories, relevant files).
+2. **Middle**: Work happens. Tool calls, reasoning, intermediate results accumulate.
+3. **End**: Outcome is reached. Learnings are extracted and stored to memory.
+
+Session metadata worth tracking:
+
+- Start time and duration
+- Agent ID and model used
+- Tools invoked (names and counts)
+- Files read and written
+- Tokens consumed (input + output)
+- Outcome: completed, failed, abandoned
+- Cost (if available)
+
+This metadata becomes the raw material for episodic memory. OAK CI captures this automatically via `agent_runs` and `sessions` tables.
+
+### Session Boundaries
+
+Deciding when to start a new session vs. continue an existing one:
+
+**Start a new session when:**
+- The user's goal has fundamentally changed
+- The previous session ended with a clear outcome
+- Context has grown past the compaction threshold and a clean start is cheaper than summarization
+- A different agent or model is better suited to the new task
+
+**Continue the existing session when:**
+- The new request builds directly on prior work
+- Relevant context (variable bindings, file state, intermediate results) would be lost
+- The user explicitly asks to continue
+
+**Session continuity** (bridging sessions):
+- Generate a session summary at the end of each session
+- Store key decisions, files touched, and open questions
+- Load this summary at the start of the next related session
+- This is cheaper than maintaining a massive continuous context
+
+---
+
+## Context Rot
+
+Context rot is the degradation of model performance as the context window fills. It is **not linear** -- performance holds steady for a while, then falls off a cliff.
+
+### The Degradation Curve
+
+Empirical behavior across major LLMs:
+
+```
+Performance
+  |████████████████████████
+  |                        ████████
+  |                                ████
+  |                                    ███
+  |                                       ██
+  |                                         █
+  |__________________________________________|___
+  0%        30%       50%       70%      100%
+                Context Window Usage
+```
+
+- **0-35% capacity**: Performance is roughly constant. The model handles instructions, history, and retrieval well.
+- **35-65% capacity**: Gradual degradation. The model starts missing details in the middle of context.
+- **65-80% capacity**: Noticeable decline. Instruction-following weakens, hallucinations increase.
+- **80%+ capacity**: Sharp decline. The model may ignore instructions, contradict itself, or lose track of the goal.
+
+These thresholds vary by model and task. Complex reasoning tasks degrade earlier than simple retrieval tasks.
+
+### Position Bias
+
+Models do not attend equally to all positions in the context window:
+
+- **Primacy effect**: Content at the beginning of context (system prompt, first instructions) gets disproportionate attention.
+- **Recency effect**: Content at the end (most recent messages) also gets strong attention.
+- **Lost in the middle**: Content in the middle of a long context receives the least attention.
+
+**Mitigations:**
+
+1. Place critical instructions in the system prompt (beginning of context).
+2. Repeat key instructions or constraints near the end of context, especially after compaction.
+3. Use XML tags or markdown headers to create clear section boundaries -- these act as attention anchors.
+4. When retrieving context, place the most relevant items closest to the current turn (end of context).
+
+### Causes of Context Rot
+
+| Cause | Mechanism | Mitigation |
+|---|---|---|
+| Token accumulation | Context window fills with conversation history | Compaction or summarization before 60% capacity |
+| Instruction dilution | Instructions become a smaller percentage of total context | Repeat key instructions; use XML section tags |
+| Contradictory information | Earlier context conflicts with later corrections | Explicit "latest wins" rules; remove outdated content |
+| Tool result bloat | Verbose tool outputs (file contents, search results) consume tokens | Summarize tool results after processing; drop raw output |
+| Goal drift | Original goal buried under conversation noise | Maintain a goal scratchpad; restate goals after compaction |
+| Retrieval noise | Irrelevant retrieved context dilutes signal | Filter retrieval results aggressively; prefer precision over recall |
+
+---
+
+## Multi-Agent Session Management
+
+When multiple agents collaborate, context management becomes a distributed systems problem. Three fundamental patterns exist.
+
+### Pattern 1: Shared Context
+
+All agents read from and write to the same context window (or shared document).
+
+```
+┌─────────────────────────────────┐
+│        Shared Context           │
+│  ┌───────┐ ┌───────┐ ┌───────┐ │
+│  │Agent A│ │Agent B│ │Agent C│ │
+│  └───────┘ └───────┘ └───────┘ │
+└─────────────────────────────────┘
+```
+
+**Strengths:**
+- All agents see the full picture
+- No communication overhead
+- Simple to implement
+
+**Weaknesses:**
+- Context bloats N times faster (each agent's output adds to shared context)
+- Agents may contradict each other
+- Hard to scale past 2-3 agents
+- No isolation: one agent's verbose output degrades context for all
+
+**Best for:** Small teams of tightly-coupled agents working on the same artifact.
+
+### Pattern 2: Separate Contexts (Isolation)
+
+Each agent has its own context window. Communication happens via structured messages.
+
+```
+┌───────────┐   message   ┌───────────┐
+│  Agent A   │ ──────────→ │  Agent B   │
+│  (own ctx) │ ←────────── │  (own ctx) │
+└───────────┘             └───────────┘
+```
+
+**Strengths:**
+- Each agent gets focused, relevant context
+- No cross-contamination
+- Scales to many agents
+- Agents can use different models optimized for their task
+
+**Weaknesses:**
+- Communication overhead (messages must be explicit)
+- Risk of information loss at boundaries
+- Harder to coordinate complex multi-step work
+
+**Best for:** Diverse tasks where each agent needs specialized context (e.g., one agent researches, another codes, another reviews).
+
+### Pattern 3: Hybrid (Orchestrator + Workers)
+
+An orchestrator agent maintains shared state. Worker agents operate in isolation with task-specific context. Results flow back through the orchestrator.
+
+```
+              ┌──────────────┐
+              │ Orchestrator  │
+              │ (shared state)│
+              └──┬───┬───┬──┘
+                 │   │   │
+          ┌──────┘   │   └──────┐
+          ▼          ▼          ▼
+    ┌──────────┐ ┌──────────┐ ┌──────────┐
+    │ Worker A  │ │ Worker B  │ │ Worker C  │
+    │ (own ctx) │ │ (own ctx) │ │ (own ctx) │
+    └──────────┘ └──────────┘ └──────────┘
+```
+
+**Strengths:**
+- Workers get clean, focused context (no pollution from other workers)
+- Orchestrator maintains the big picture
+- Workers can run in parallel
+- Scales well
+
+**Weaknesses:**
+- Orchestrator context can still bloat if many workers report back
+- Design complexity: must define clear task boundaries and result formats
+
+**Best for:** Production agent systems. This is the pattern used by Claude Code's team mode, OAK's analysis agents, and most multi-agent frameworks.
+
+### Choosing a Pattern
+
+| Factor | Shared | Isolated | Hybrid |
+|---|---|---|---|
+| Number of agents | 2-3 | Any | Any |
+| Task coupling | Tight | Loose | Mixed |
+| Context efficiency | Low | High | High |
+| Implementation effort | Low | Medium | High |
+| Scalability | Poor | Good | Good |
+
+---
+
+## Compaction Strategies
+
+When context grows too large, you must compact it. The strategy you choose determines what knowledge survives compression.
+
+### Strategy 1: Last-N Messages
+
+Keep only the most recent N conversation turns. Discard everything older.
+
+**How it works:**
+```
+Before: [msg1, msg2, msg3, msg4, msg5, msg6, msg7, msg8]
+After (N=4): [msg5, msg6, msg7, msg8]
+```
+
+**Characteristics:**
+- Simple and predictable
+- Token usage is bounded
+- Completely loses early context (instructions, goals, decisions made early)
+- No computation overhead
+
+**Best for:** Stateless chat applications, simple Q&A bots, situations where early context is truly irrelevant.
+
+**Not suitable for:** Multi-step tasks where early instructions or decisions matter.
+
+### Strategy 2: Recursive Summarization
+
+Summarize old messages into a running summary. Keep the summary plus recent messages.
+
+**How it works:**
+```
+Before: [summary_v1, msg4, msg5, msg6, msg7, msg8, msg9, msg10]
+Trigger: context > 60% capacity
+After:  [summary_v2 (covers msg1-msg7), msg8, msg9, msg10]
+```
+
+Where `summary_v2` incorporates `summary_v1` and `msg4-msg7` into a new summary.
+
+**Characteristics:**
+- Preserves a compressed version of all history
+- Moderate token efficiency
+- Risk: summarization losses compound over time (the "telephone game" effect)
+- Each compaction step loses some fidelity
+- Works best when the model doing summarization is high quality
+
+**Implementation guidance:**
+- Trigger summarization at 55-65% context capacity (before degradation begins)
+- Use structured summaries: decisions made, files changed, open questions, key facts
+- Include explicit section for "instructions that must be preserved"
+- Consider having the summary reviewed/approved before discarding originals
+
+### Strategy 3: Manus Hybrid (Structured Scratchpad)
+
+Maintain two zones: a **verbatim zone** (recent turns, kept as-is) and a **summary zone** (older turns, compressed). Alongside both, maintain a **structured scratchpad** that is never summarized.
+
+**How it works:**
+```
+Context layout:
+┌─────────────────────────────┐
+│ System Prompt (fixed)        │
+├─────────────────────────────┤
+│ Scratchpad (preserved)       │
+│  - Current goal              │
+│  - Key facts learned         │
+│  - Decisions made            │
+│  - Open questions            │
+│  - Files modified            │
+├─────────────────────────────┤
+│ Summary Zone (compressed)    │
+│  "Earlier: researched auth   │
+│   options, chose JWT..."     │
+├─────────────────────────────┤
+│ Verbatim Zone (recent turns) │
+│  [msg8, msg9, msg10]         │
+└─────────────────────────────┘
+```
+
+**Characteristics:**
+- Highest context preservation of any compaction strategy
+- The scratchpad acts as a lossless knowledge store across compactions
+- More complex to implement: requires maintaining the scratchpad format
+- The scratchpad itself must be kept concise (it is never compressed)
+
+**Implementation guidance:**
+- Define scratchpad structure upfront (what sections, what format)
+- Update the scratchpad explicitly during the session (not just at compaction time)
+- On compaction: compress the narrative (conversation), but copy the scratchpad verbatim
+- Cap scratchpad size (e.g., 2000 tokens) to prevent it from becoming its own bloat problem
+
+### Strategy Comparison
+
+| Strategy | Context Preservation | Simplicity | Token Efficiency | Compounding Loss | Best For |
+|---|---|---|---|---|---|
+| Last-N | Low | High | High | None (hard cutoff) | Short tasks, chat |
+| Recursive Summarization | Medium | Medium | Medium | Yes (telephone game) | Medium-length sessions |
+| Manus Hybrid | High | Low | Medium | Minimal (scratchpad preserved) | Complex multi-step tasks |
+| Full (no compaction) | Perfect | Highest | Lowest | N/A | Sessions under 30% capacity |
+
+**Rule of thumb:** If your agent sessions routinely exceed 50% context capacity, you need a compaction strategy. If they involve multi-step reasoning or long-running tasks, prefer the Manus Hybrid approach.
+
+---
+
+## Memory Architecture (5 Layers)
+
+From Google's whitepaper, agent memory has five layers, analogous to human memory systems. Each layer has different lifetime, retrieval characteristics, and storage requirements.
+
+### Layer 1: Sensory Memory (Immediate Context)
+
+The current turn's raw input: the user's latest message, tool results just returned, documents just retrieved.
+
+- **Lifetime:** Single turn
+- **Size:** Small (one turn's worth of data)
+- **Analogy:** What you are looking at right now
+- **Implementation:** The latest entries in the conversation messages array
+- **Key concern:** Filter aggressively. Not everything the tools return needs to stay in context.
+
+### Layer 2: Short-Term Memory (Session Context)
+
+The conversation history within the current session. Grows with each turn.
+
+- **Lifetime:** Current session
+- **Size:** Grows linearly; subject to context rot
+- **Analogy:** What you have been thinking about for the last hour
+- **Implementation:** The conversation messages array, subject to compaction
+- **Key concern:** This is where context rot lives. Apply compaction strategies from the previous section.
+
+### Layer 3: Episodic Memory (What Happened)
+
+Records of past events and experiences. Retrieved when relevant to the current task.
+
+- **Lifetime:** Long-term (persists across sessions)
+- **Content:** Specific events: "Last time we refactored the auth module, tests broke because mock setup was order-dependent"
+- **Retrieval:** Semantic search triggered by current task context
+- **OAK CI equivalent:** `memory_observations` with types `bug_fix` and `gotcha`
+- **Key concern:** Must be retrievable by relevance, not just recency. Vector search is preferred.
+
+### Layer 4: Semantic Memory (Facts and Concepts)
+
+General knowledge about the domain, the codebase, or the project. Relatively stable over time.
+
+- **Lifetime:** Long-term, updated infrequently
+- **Content:** "This codebase uses the repository pattern for data access" or "The API rate limit is 100 requests per minute"
+- **Retrieval:** Semantic search, or loaded proactively based on file/topic context
+- **OAK CI equivalent:** `memory_observations` with types `discovery` and `decision`
+- **Key concern:** Keep entries atomic and factual. Vague or compound observations degrade search quality.
+
+### Layer 5: Procedural Memory (How To Do Things)
+
+Skills, procedures, and workflows. The agent's "muscle memory."
+
+- **Lifetime:** Permanent (updated with project evolution)
+- **Content:** "To add a new API endpoint: create route file, add service, write tests, update OpenAPI spec"
+- **Implementation:** System prompts, constitution files, skill files, templates
+- **OAK CI equivalent:** Constitution (`oak/constitution.md`), skill files, agent task definitions
+- **Key concern:** This is the most valuable memory layer. It should be curated by humans, not auto-generated.
+
+### How the Layers Integrate
+
+At each turn, the agent assembles context from all five layers:
+
+```
+Context Assembly (per turn):
+
+  Layer 5: System prompt + skill instructions    [always present, fixed cost]
+      │
+  Layer 4: Retrieved semantic memories           [loaded at session start or on topic change]
+      │
+  Layer 3: Retrieved episodic memories            [searched per-turn based on current task]
+      │
+  Layer 2: Session history (compacted)            [growing, subject to compaction]
+      │
+  Layer 1: Current turn input + tool results      [fresh each turn]
+      │
+      ▼
+  ┌──────────────────┐
+  │  Model Inference  │
+  └──────────────────┘
+```
+
+**Token budget allocation** (approximate, for a 200K-token model):
+
+| Layer | Budget | Notes |
+|---|---|---|
+| Layer 5 (Procedural) | 10-20K tokens | System prompt, skills, constitution |
+| Layer 4 (Semantic) | 5-10K tokens | Retrieved facts, project knowledge |
+| Layer 3 (Episodic) | 3-5K tokens | Relevant past experiences |
+| Layer 2 (Session) | 50-100K tokens | Conversation history (compacted) |
+| Layer 1 (Sensory) | 10-30K tokens | Current tool results, retrieved docs |
+| Reserved for response | 10-30K tokens | Model's output budget |
+
+These are guidelines, not rules. Adjust based on your model's context window and task requirements.
+
+---
+
+## Practical Patterns for Agent Loops
+
+### The Observe-Think-Act-Reflect Loop
+
+The core agent loop with explicit context management at each phase:
+
+**1. Observe** -- Gather context before reasoning.
+- Retrieve relevant memories (`oak_search`, `oak_context`)
+- Read relevant files
+- Check task state and dependencies
+- Load any session scratchpad from prior compaction
+
+**2. Think** -- Reason about the gathered context.
+- Extended thinking / chain-of-thought helps here
+- Consider multiple approaches before acting
+- Identify what additional context might be needed
+
+**3. Act** -- Take action based on reasoning.
+- Write code, call APIs, modify files
+- Use tools to verify results (run tests, check output)
+- Keep tool calls focused: avoid retrieving more context than needed
+
+**4. Reflect** -- Store learnings from the outcome.
+- If something unexpected happened, store it as episodic memory (`oak_remember`)
+- Update the session scratchpad with new facts, decisions, and open questions
+- If a general pattern was discovered, store it as semantic memory
+
+This loop naturally integrates all five memory layers: Layer 5 provides the loop structure itself, Layers 3-4 feed the Observe phase, Layer 2 provides session continuity, and Layer 1 is the current turn's input.
+
+### Context Budget Management
+
+Monitor context usage and trigger compaction proactively:
+
+```
+Per-turn context check:
+
+  current_usage = system_prompt + session_history + retrieval + pending_response
+  capacity = model_context_window
+
+  if current_usage > 0.55 * capacity:
+      trigger_compaction()       # Summarize old turns, preserve scratchpad
+
+  if current_usage > 0.75 * capacity:
+      aggressive_compaction()    # Deeper summarization, drop tool results
+
+  if current_usage > 0.90 * capacity:
+      emergency_compaction()     # Keep only scratchpad + last 3 turns
+```
+
+**Key principle:** Compact early, compact often. It is better to summarize 10 turns when you have headroom than to be forced into emergency compaction that loses critical context.
+
+### Goal Persistence
+
+Goal drift is the most common cause of agent failure in long sessions. The original task gets buried under conversation history and the agent starts optimizing for the wrong thing.
+
+**Mitigations:**
+
+1. **Explicit goal statement**: Store the current goal in the session scratchpad. Not just "fix the bug" but "fix the authentication timeout bug in `auth_service.py` where JWT tokens expire during long-running requests."
+
+2. **Goal restatement**: After every compaction, restate the goal. After every N turns (e.g., 10), restate the goal.
+
+3. **Goal decomposition**: Break complex goals into sub-goals. Track which sub-goals are complete and which remain.
+
+4. **Completion criteria**: Define upfront what "done" looks like. "The fix is done when: (a) the timeout no longer occurs, (b) existing tests pass, (c) a new test covers the edge case."
+
+### When to Store Memories
+
+Not every observation deserves to be a memory. Store memories when:
+
+| Signal | Memory Type | Example |
+|---|---|---|
+| Something broke unexpectedly | `gotcha` | "Mocking `datetime.now()` in this codebase requires patching the module-level import, not `datetime.datetime.now`" |
+| A bug was fixed and the root cause was non-obvious | `bug_fix` | "The flaky test was caused by test ordering -- `test_auth` was leaking a database connection" |
+| An architectural pattern was discovered | `discovery` | "All API routes in this project use the decorator pattern from `base_route.py`" |
+| A deliberate choice was made between alternatives | `decision` | "Chose SQLite over PostgreSQL for CI data because it requires zero configuration and the data is machine-local" |
+| A trade-off was identified | `trade_off` | "Compacting at 55% capacity loses less context but triggers more frequent compactions, increasing latency" |
+
+**Do not store:**
+- Obvious facts anyone could find by reading the code
+- Session-specific state that will not be relevant later
+- Speculative conclusions from reading a single file
+- Anything already documented in the project's constitution or README
+
+---
+
+## Key Takeaways
+
+1. **Sessions are ephemeral; memory is durable.** Do not try to make sessions do the job of memory, or vice versa.
+
+2. **Context rot is non-linear.** Performance holds steady, then falls off a cliff. Compact before you hit the cliff, not after.
+
+3. **Position matters.** Put critical instructions at the start and end of context. Use structural markers (XML tags, headers) to create attention anchors.
+
+4. **Prefer the hybrid pattern** for multi-agent systems. Isolation protects each agent's context quality; the orchestrator maintains coherence.
+
+5. **Compaction is not optional** for long-running agents. Choose a strategy that preserves structured knowledge (decisions, goals, facts) even as narrative history is compressed.
+
+6. **Memory has layers.** Procedural memory (skills, constitution) is the most valuable. Episodic memory (what happened) is the most underused. Invest in both.
+
+7. **Goals drift. State them explicitly, restate them often.** A scratchpad with the current goal, sub-goals, and completion criteria prevents the most common mode of agent failure.

--- a/.cursor/skills/context-engineering/references/before-after-examples.md
+++ b/.cursor/skills/context-engineering/references/before-after-examples.md
@@ -1,0 +1,331 @@
+# Before/After Examples
+
+Concrete transformations showing how context engineering techniques improve real prompts. Each example: **Before** (problematic), **Diagnosis** (what's wrong), **Techniques Applied**, **After** (improved).
+
+---
+
+## 1. Vague Prompt to Structured Prompt
+
+### Before
+```
+Help me with this code. It's not working right and I need it fixed.
+```
+
+### Diagnosis
+- "Not working" gives zero actionable detail -- no code, no error, no expected behavior
+- No output format specified
+
+### Techniques Applied
+- **Be Clear and Direct**: state the exact problem and expected vs actual behavior
+- **XML Tags**: separate code, error, and instructions
+
+### After
+```xml
+<code language="python">
+def calculate_discount(price, tier):
+    if tier == "gold": return price * 0.8
+    if tier == "silver": return price * 0.9
+    return price
+</code>
+
+<error>calculate_discount(100, "Gold") returns 100 instead of 80.</error>
+
+<instructions>
+1. Identify why the function fails for "Gold" (capital G)
+2. Fix the bug
+3. Add handling for invalid tier values (return price unchanged, log a warning)
+</instructions>
+
+<output_format>Root cause (one sentence), fixed code, test cases.</output_format>
+```
+
+**Why it works:** The model knows exactly what is broken, what the expected behavior is, and what to produce. No ambiguity about scope or success criteria.
+
+---
+
+## 2. Wall of Text to XML-Structured Context
+
+### Before
+```
+Here's my API spec and some error logs and the database schema. The API
+spec says we have a /users endpoint that accepts POST with name and email.
+The email should be unique. Here are the error logs: [2024-01-15 14:23:01]
+IntegrityError: duplicate key violates "users_email_key" Request: POST
+/users {"name": "Jane", "email": "jane@test.com"} And the schema is
+CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT
+NOT NULL UNIQUE). Why am I getting these errors?
+```
+
+### Diagnosis
+- Three data sources in one paragraph with no separation
+- Question buried at the end -- model reads data without knowing the goal
+
+### Techniques Applied
+- **XML Tags**: each data source in its own labeled section
+- **Long Context Tips**: front-load the question
+
+### After
+```xml
+<question>
+Why do duplicate key errors occur on POST /users? Provide: root cause, fix, error response.
+</question>
+
+<error_logs>
+[2024-01-15 14:23:01] IntegrityError: duplicate key violates "users_email_key"
+  Request: POST /users {"name": "Jane", "email": "jane@test.com"}
+[2024-01-15 14:25:12] IntegrityError: duplicate key violates "users_email_key"
+  Request: POST /users {"name": "John", "email": "jane@test.com"}
+</error_logs>
+
+<database_schema>
+CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL UNIQUE);
+</database_schema>
+
+<api_spec>POST /users — Body: { name, email } — email must be unique</api_spec>
+```
+
+**Why it works:** Each data source is labeled. The question is front-loaded so the model reads data with the goal already in mind.
+
+---
+
+## 3. Bloated System Prompt to Altitude-Optimized
+
+### Before (22 generic directives)
+```
+You are an AI assistant. Be helpful, harmless, honest. Be polite.
+Use clear language. Be concise but thorough. Prioritize accuracy.
+Always cite sources. Be creative when appropriate. Ask clarifying
+questions. Be empathetic. Use examples. Stay on topic. [... 10 more ...]
+```
+
+### Diagnosis
+- None specific enough to change behavior -- "be helpful" is default
+- Contradictions: "be concise" vs "be thorough"
+- No role, no domain, no output conventions
+
+### Techniques Applied
+- **Altitude optimization**: raise to principled guidance
+- **System prompt design**: define role with domain expertise
+
+### After
+```xml
+<role>
+Code reviewer. Domain: Django REST APIs with PostgreSQL. Senior level.
+</role>
+
+<constraints>
+- Flag security issues as CRITICAL regardless of other priorities
+- If a change affects schema, always mention migration safety
+- When trade-offs exist, state both options and recommend one
+- Say "I'm not sure" rather than guessing on library-specific behavior
+</constraints>
+
+<output_conventions>
+- Reference file:line_number for each finding
+- Severity: CRITICAL, WARNING, SUGGESTION
+- Include corrected code for CRITICAL and WARNING items
+</output_conventions>
+```
+
+**Why it works:** 22 vague directives became 7 specific rules. Generic advice is gone; domain-specific guidance takes its place.
+
+---
+
+## 4. Context-Stuffed Agent to Compress and Isolate
+
+### Before
+```
+System prompt permanently includes:
+- Full API docs (8K tokens), database schema (3K), error codes (2K),
+  coding standards (1.5K), changelog (4K) = ~18,500 tokens always loaded
+```
+
+### Diagnosis
+- Most reference data used rarely (~5% per conversation)
+- 18K tokens permanently occupied; position bias weakens middle sections
+- Stale data in the system prompt is worse than no data
+
+### Techniques Applied
+- **Isolate**: move reference data behind tool calls
+- **Compress**: summarize what remains
+- **Select**: retrieve only what the current query needs
+
+### After
+```
+System prompt (800 tokens): role, principles, tool instructions
+
+Tools:
+- search_api_docs(endpoint) -> docs for one endpoint
+- query_schema(table_name) -> schema for one table
+- lookup_error_code(code) -> one error definition
+- get_coding_standards(topic) -> relevant standards
+```
+
+**Why it works:** 18,500 to 800 tokens (95% reduction). Data always current (retrieved live). Model attention focused. Cost drops proportionally.
+
+---
+
+## 5. Stateless Agent to Memory-Augmented
+
+### Before
+```
+User: "Can you help me with the auth module?"
+Agent: Starts from scratch. Doesn't know about the circular import
+       bug fixed last week or the refactor merged yesterday.
+```
+
+### Diagnosis
+- No persistent memory -- each session reinvents the wheel
+- Same gotchas hit repeatedly; user re-explains context every time
+
+### Techniques Applied
+- **Write**: store observations as they emerge
+- **Select**: retrieve relevant memories at session start
+
+### After
+```
+Session start: Agent receives injected context:
+  - Recent session summaries, active gotchas, unresolved observations
+
+During work: Agent stores learnings:
+  oak_remember("Auth circular import caused by module-level import
+  of UserModel. Fixed by moving inside function.",
+  memory_type="bug_fix", context="src/services/auth_service.py")
+
+Next session: "Help with the auth module?"
+  Agent already knows about the circular import and last week's refactor.
+```
+
+**Why it works:** The agent compounds knowledge across sessions. Gotchas caught once stay caught.
+
+---
+
+## 6. Poor Few-Shot to Diverse Multishot
+
+### Before (2 trivial examples)
+```
+Convert descriptions to SQL queries.
+Example: "Get all users" -> SELECT * FROM users;
+Example: "Get active users" -> SELECT * FROM users WHERE active = true;
+Now convert: "Get the top 5 customers by total spending last quarter"
+```
+
+### Diagnosis
+- 2 examples, both trivially simple (single table, no joins)
+- Actual task requires JOIN, GROUP BY, ORDER BY, LIMIT, date filtering
+- No schema -- model guesses table and column names
+
+### Techniques Applied
+- **Multishot examples**: 5 diverse examples, simple to complex
+- **XML Tags**: structure examples and provide schema
+
+### After
+```xml
+Convert natural language to PostgreSQL using this schema:
+
+<schema>
+users(id, name, email, created_at)
+orders(id, user_id, total_amount, created_at, status)
+products(id, name, price, category)
+order_items(order_id, product_id, quantity)
+</schema>
+
+<examples>
+<example>
+<input>Get all users</input>
+<output>SELECT * FROM users;</output>
+</example>
+<example>
+<input>Active orders with user names</input>
+<output>SELECT u.name, o.id, o.total_amount
+FROM orders o JOIN users u ON u.id = o.user_id WHERE o.status = 'active';</output>
+</example>
+<example>
+<input>Count orders per user, highest first</input>
+<output>SELECT u.name, COUNT(o.id) AS order_count
+FROM users u LEFT JOIN orders o ON o.user_id = u.id
+GROUP BY u.id, u.name ORDER BY order_count DESC;</output>
+</example>
+<example>
+<input>Revenue by product category this year</input>
+<output>SELECT p.category, SUM(oi.quantity * p.price) AS revenue
+FROM order_items oi JOIN products p ON p.id = oi.product_id
+JOIN orders o ON o.id = oi.order_id
+WHERE o.created_at >= DATE_TRUNC('year', CURRENT_DATE)
+GROUP BY p.category ORDER BY revenue DESC;</output>
+</example>
+<example>
+<input>Users who never placed an order</input>
+<output>SELECT u.name, u.email FROM users u
+LEFT JOIN orders o ON o.user_id = u.id WHERE o.id IS NULL;</output>
+</example>
+</examples>
+
+<input>Get the top 5 customers by total spending last quarter</input>
+```
+
+**Why it works:** Examples progress simple to complex, covering JOINs, GROUP BY, LEFT JOIN for negation, date functions. Schema is explicit.
+
+---
+
+## 7. Unconstrained Output to Prefilled and Formatted
+
+### Before
+```
+Analyze this error log and tell me what happened.
+[error log contents]
+```
+
+### Diagnosis
+- No output structure -- could be a paragraph, list, or narrative
+- "What happened" is open-ended; no actionable structure
+
+### Techniques Applied
+- **Output format**: define exact structure expected
+- **Be Clear and Direct**: bound the scope of analysis
+
+### After
+```xml
+<instructions>
+Analyze this error log. Identify root cause, impact, and fix.
+Respond in exactly this JSON format -- no additional commentary.
+</instructions>
+
+<error_log>[error log contents]</error_log>
+
+<output_format>
+{
+  "root_cause": {
+    "error": "specific error message",
+    "location": "file:line or service",
+    "explanation": "one sentence"
+  },
+  "impact": {
+    "user_facing": "what the user experienced",
+    "scope": "affected users/requests if determinable"
+  },
+  "fix": {
+    "immediate": "what to do now",
+    "preventive": "what to change to prevent recurrence"
+  }
+}
+</output_format>
+```
+
+**Why it works:** The JSON schema acts as a contract. The model produces parseable output, and the three-part structure ensures analysis is actionable, not just descriptive.
+
+---
+
+## Pattern Summary
+
+| Transformation | Key Technique | Typical Improvement |
+|---|---|---|
+| Vague to Structured | Clarity + XML tags | Consistent, relevant responses |
+| Wall of text to XML sections | XML structure | Better information extraction |
+| Low altitude to Right altitude | Altitude optimization | Smaller prompt, better adherence |
+| Context-stuffed to Tool-based | Isolate + Select | 90%+ token reduction, fresher data |
+| Stateless to Memory-augmented | Write + Select | Compounding effectiveness over time |
+| Single example to Diverse multishot | Multishot examples | Edge case handling, format consistency |
+| Unconstrained to Formatted | Output format + Prefill | Parseable, actionable output |
+
+Each transformation applies techniques from [Prompt Engineering Foundations](prompt-foundations.md). For system-level patterns, see [System Prompt Design](system-prompt-design.md). For agent-specific strategies, see [Agent Context Patterns](agent-context-patterns.md).

--- a/.cursor/skills/context-engineering/references/context-engineering-framework.md
+++ b/.cursor/skills/context-engineering/references/context-engineering-framework.md
@@ -1,0 +1,255 @@
+# The Context Engineering Framework
+
+Context engineering is designing the complete information environment a model receives at inference time. Four core strategies — Write, Select, Compress, Isolate — ensure the model has the right information, in the right form, at the right moment.
+
+## The Core Insight
+
+Context engineering is not prompt engineering. A prompt is what you type. Context is *everything* the model sees: system prompt + conversation history + tool definitions + tool results + retrieved documents + injected memories + file contents + structured metadata.
+
+A well-engineered prompt inside poorly-engineered context will underperform. A mediocre prompt inside well-engineered context will often succeed. **The context is the product.**
+
+The question shifts from "What should I tell the model?" to "What should the model see, and when should it see it?"
+
+---
+
+## Strategy 1: Write — Craft the Persistent Context
+
+The system prompt persists across every turn, anchoring behavior, tone, and decision-making. It is the highest-leverage piece of context.
+
+### The Altitude Scale
+
+Altitude is the level of abstraction at which you write instructions. Most system prompts fail because they target the wrong altitude.
+
+| Level | Example | Problem |
+|---|---|---|
+| Too High (30,000 ft) | "Be a helpful coding assistant" | No actionable guidance |
+| Too Low (ground level) | "Always use 4-space indentation, prefer f-strings over .format(), use pathlib instead of os.path" | Brittle, doesn't generalize, model may ignore the list |
+| Right Altitude (10,000 ft) | "Follow the project's existing code style. When uncertain, match the patterns in nearby files." | Principled, adaptable, scales to new situations |
+
+Right-altitude examples across domains:
+
+| Domain | Too High | Right Altitude |
+|---|---|---|
+| Code review | "Review code carefully" | "Identify bugs that would cause runtime failures, focusing on edge cases the author likely didn't test" |
+| Customer support | "Help the customer" | "Acknowledge the customer's specific situation before moving to resolution. Gather account info early." |
+| Data analysis | "Analyze this data" | "Check for quality issues first (missing values, type mismatches), then answer using appropriate aggregations" |
+| Writing | "Help me write" | "Match the style of the user's existing text. Preserve their voice; improve clarity without imposing a formula." |
+
+**The altitude test:** If your instruction would still be correct after the codebase or domain changes significantly, it is at the right altitude. If it would break, it is too low. If it provides no guidance for concrete decisions, it is too high.
+
+### Canonical Examples in System Prompts
+
+Instructions tell the model what to do. Examples *show* it. When the two conflict, examples usually win — models pattern-match on demonstrations more reliably than they follow abstract rules.
+
+Include 2-3 gold-standard input/output pairs directly in the system prompt:
+
+```
+You are a code review assistant.
+
+## Example Review
+
+**Input code:**
+def get_user(id):
+    user = db.query(f"SELECT * FROM users WHERE id = {id}")
+    return user[0]
+
+**Your review:**
+1. **SQL injection** (critical): Use parameterized queries:
+   `db.query("SELECT * FROM users WHERE id = ?", [id])`
+2. **Unhandled empty result** (bug): `user[0]` raises IndexError
+   if no user matches. Check the result length first.
+3. **Naming**: `id` shadows the built-in. Use `user_id`.
+
+Apply this structure: prioritize by severity, explain the why, show the fix.
+```
+
+This single example establishes the review structure, severity ordering, inline-fix convention, and explanatory tone — all by demonstration.
+
+### System Prompt as Constitution
+
+A system prompt can function as a constitution: a governing document establishing principles, boundaries, and quality standards for an entire project.
+
+> Cross-reference: The `/project-governance` skill creates constitutions that serve exactly this purpose — the Write strategy applied at project scale.
+
+---
+
+## Strategy 2: Select — Choose What Enters the Context
+
+Every token in the context window competes for the model's attention. Select ensures only high-value, relevant information occupies that space.
+
+### Minimal Viable Toolsets
+
+Fewer, well-described tools lead to better tool selection. Tool sprawl causes selection errors and wastes tokens.
+
+| Quality | Tool Description | Issue |
+|---|---|---|
+| Bad | "search: A tool for searching" | What does it search? What format? |
+| Bad | "find_and_replace_in_files: Searches and optionally replaces, supports regex, globs, recursive traversal" | Two tools in one |
+| Good | "grep_codebase: Search file contents with regex. Returns matching lines with file paths and line numbers." | Clear scope, output, use case |
+| Good | "edit_file: Replace a specific string in a file. old_string must appear exactly once." | Precise contract |
+
+**Principles:** single responsibility per tool, verb-based names, remove overlapping tools, conditionally load rarely-used tools.
+
+### Retrieval Quality
+
+RAG is the Select strategy operationalized. Quality matters far more than quantity.
+
+**Precision over recall.** Injecting 20 vaguely-related documents is worse than 3 highly relevant ones. Irrelevant results actively mislead by introducing noise that competes with signal.
+
+Key practices: re-rank after initial retrieval, limit to top-K (typically 3-5), chunk at semantic boundaries (sections, functions) not fixed token counts, test retrieval quality independently.
+
+### Dynamic Context Selection
+
+Route queries to different context sources based on what the query needs:
+
+```
+"I was charged twice"       -> billing KB + account lookup tool
+"App crashes on login"      -> troubleshooting docs + error log tool
+"How do I export my data?"  -> product docs + feature guide
+"I want to cancel"          -> retention playbook + account status tool
+```
+
+Implementation patterns: classify-then-select (two-step), model self-selection via tool descriptions, metadata pre-filtering, or combinations of these.
+
+---
+
+## Strategy 3: Compress — Reduce Without Losing
+
+Conversations grow. Tool results are verbose. Left unchecked, context fills and performance degrades. Compress fights context bloat while preserving essential information.
+
+### Compaction Techniques
+
+| Technique | How It Works | When to Use |
+|---|---|---|
+| Summarization | LLM summarizes older conversation history | Long conversations approaching limits |
+| Note-taking scratchpad | Agent writes key findings to a persistent scratchpad | Complex research tasks |
+| Sub-agent delegation | Spawn focused sub-agents with narrow context; receive only conclusions | Multi-domain tasks |
+| Tool result clearing | Replace verbose tool output with summary after processing | Large tool responses |
+| Recursive summarization | Summarize existing summaries | Very long sessions |
+
+### The Two-Phase Compression Approach
+
+A production pattern combining techniques:
+
+**Phase 1 — Sliding window:** Keep the last N messages verbatim (active working context).
+
+**Phase 2 — Structured summarization:** Compress older messages into: key facts established, decisions made with rationale, open questions, constraints discovered.
+
+This preserves detail where it matters most (recent context) while retaining essentials from earlier. Maintaining a "facts learned" scratchpad alongside the conversation enhances this — the scratchpad becomes a compressed representation of the entire session's knowledge.
+
+### Token Budget Analysis
+
+Budget tokens deliberately rather than filling the window opportunistically.
+
+```
+Available context = Window size - system prompt - tool descriptions
+                  - conversation history - retrieved docs - response budget
+```
+
+| Component | 8K | 32K | 128K | 200K |
+|---|---|---|---|---|
+| System prompt | 1,000 (12%) | 2,000 (6%) | 4,000 (3%) | 5,000 (2.5%) |
+| Tool descriptions | 500 (6%) | 1,500 (5%) | 3,000 (2%) | 4,000 (2%) |
+| Conversation | 2,500 (31%) | 12,000 (37%) | 50,000 (39%) | 80,000 (40%) |
+| Retrieved docs | 1,500 (19%) | 8,000 (25%) | 35,000 (27%) | 55,000 (27.5%) |
+| **Response budget** | **2,500 (31%)** | **8,500 (27%)** | **36,000 (28%)** | **56,000 (28%)** |
+
+**Rules:** Reserve 20-30% for response (truncation degrades quality). Compress proactively, not reactively. System prompt and tool descriptions are fixed costs; conversation and retrieved docs are where compression pays off.
+
+---
+
+## Strategy 4: Isolate — Move Information Out of Main Context
+
+The most powerful strategy for scaling. Move information to external storage, retrieve just-in-time. The context window becomes working memory, not permanent storage.
+
+### Just-in-Time Retrieval
+
+Don't load information until the model needs it.
+
+**Anti-pattern — eager loading:**
+```
+System prompt: full API docs (15K tokens) + style guide (3K)
+  + project rules (5K) + DB schema (4K) = 27K tokens before the user speaks
+```
+
+**Pattern — just-in-time:**
+```
+System prompt: role (200 tokens) + principles (300 tokens)
+  + tools: search_docs(), get_schema(), check_style() = 800 tokens
+  → detailed info retrieved on demand
+```
+
+97% fewer system prompt tokens, access to the same (or more) information.
+
+### Progressive Disclosure
+
+Structure information in layers:
+
+- **Layer 1 — Overview** (always in context): project structure, directory summaries
+- **Layer 2 — Details** (retrieved on demand): file listings with descriptions, section contents
+- **Layer 3 — Raw data** (retrieved for specific work): full file contents, complete records
+
+Each layer provides enough information to decide whether to go deeper — like navigating from a map to a neighborhood to a specific building.
+
+### Hybrid Context Loading
+
+- **Static context** (every turn): system prompt, core tools, persistent memory
+- **Dynamic context** (query-dependent): retrieved documents, relevant code files, user info
+- **Ephemeral context** (use once, then clear): raw tool results, intermediate search results, verbose API responses
+
+Most context is ephemeral — needed for one step, then dead weight. Actively managing context lifecycle (load, use, summarize, clear) keeps the window focused.
+
+---
+
+## Combining Strategies
+
+The four strategies work together. Decision framework:
+
+```
+Is the information needed on EVERY turn?
++-- Yes -> WRITE it into the system prompt
+|   +-- System prompt too long?
+|       +-- Yes -> Raise ALTITUDE or move specifics to retrieval
+|       +-- No  -> Keep it
++-- No -> Needed on SOME turns?
+    +-- Yes -> Can you predict WHEN?
+    |   +-- Yes -> SELECT (pre-filter by query type or metadata)
+    |   +-- No  -> ISOLATE (let model retrieve via tools)
+    +-- Rarely -> COMPRESS or remove entirely
+```
+
+**Combinations in practice:**
+
+| Scenario | Strategies |
+|---|---|
+| Long coding session | Write (project principles) + Isolate (file contents via tools) + Compress (summarize old turns) |
+| RAG-powered Q&A | Write (role + format) + Select (top-K docs) + Compress (multi-retrieval summaries) |
+| Research agent | Write (methodology) + Isolate (search tools) + Compress (scratchpad) + Select (curate findings) |
+| Customer support | Write (tone + policy) + Select (route to relevant KB) + Isolate (account lookup) |
+
+---
+
+## Measuring Context Quality
+
+| Signal | Likely Cause | Action |
+|---|---|---|
+| Model ignores instructions | System prompt too long or low altitude | Raise altitude, compress, move details to retrieval |
+| Wrong tool selected | Ambiguous or overlapping descriptions | Rewrite descriptions, reduce tool count |
+| Hallucinated information | Missing context | Add retrieval, improve selection |
+| Repetitive responses | Context rot (stale/redundant info) | Compress history, deduplicate |
+| Slow responses | Context too large | Compress, isolate verbose data |
+| Contradictory behavior | Conflicting instructions | Audit for contradictions, set precedence |
+| Degraded quality over time | Window filling with low-value history | Sliding-window compression, scratchpad |
+
+### Quick Diagnostic Checklist
+
+When agent performance drops, check in order:
+
+1. **System prompt over 3,000 tokens?** Raise altitude or isolate details.
+2. **More than 15 tools defined?** Reduce, merge, or conditionally load.
+3. **Conversation history over 50% of window?** Compress.
+4. **Retrieved documents relevant?** Spot-check what was actually injected.
+5. **Response budget sufficient?** Ensure 20-30% of window remains for output.
+6. **Contradictions present?** Search full context for conflicting instructions.
+
+Context engineering is iterative. Measure signals, diagnose root causes, apply strategies, measure again.

--- a/.cursor/skills/context-engineering/references/evaluation-and-testing.md
+++ b/.cursor/skills/context-engineering/references/evaluation-and-testing.md
@@ -1,0 +1,178 @@
+# Evaluation and Testing
+
+How to measure whether your context engineering is working and systematically improve it.
+
+---
+
+## Measuring Context Quality
+
+### Output Quality Dimensions
+
+| Dimension | What It Measures | How to Assess |
+|---|---|---|
+| Accuracy | Are facts and code correct? | Compare against ground truth, run tests |
+| Completeness | Does the response address the full request? | Checklist against requirements |
+| Consistency | Are responses stable across similar inputs? | Run same prompt 5-10 times, compare |
+| Relevance | Is the response focused on what was asked? | Check for tangential content |
+| Efficiency | Minimal tokens for maximum value? | Measure response length vs info density |
+| Format Compliance | Does output match specified format? | Validate against schema/template |
+
+Score each dimension independently on a 1-5 scale. A single aggregate score hides problems — a response can be accurate but verbose, or well-formatted but incomplete.
+
+### Context Quality Signals
+
+When outputs are poor, the cause is often in the context, not the model.
+
+| Signal | Indicates | Action |
+|---|---|---|
+| Model ignores late instructions | Position bias, context too long | Move instructions to start, add XML structure |
+| Hallucinated function names | Missing code context | Improve retrieval, add relevant files |
+| Generic responses | System prompt too high altitude | Lower altitude with more specific guidance |
+| Overly rigid responses | System prompt too low altitude | Raise altitude to principles |
+| Wrong tool selected | Ambiguous tool descriptions | Rewrite descriptions, reduce tool count |
+| Repeated similar answers | Context rot | Compress conversation, add diversity cues |
+| Contradicting earlier responses | Compaction lost key info | Improve compaction strategy, preserve decisions |
+
+---
+
+## A/B Testing Prompts
+
+### The Process
+1. **Baseline**: Run current prompt on 20-50 test cases, record outputs
+2. **Variant**: Modify one aspect of the prompt (not multiple changes at once)
+3. **Evaluate**: Score both sets on the quality dimensions above
+4. **Compare**: Statistical comparison (is the improvement consistent?)
+5. **Iterate**: Keep winner, test next hypothesis
+
+### What to A/B Test
+- System prompt wording (altitude changes)
+- Example selection (different multishot examples)
+- Output format instructions
+- XML structure vs plain text instructions
+- Tool descriptions
+- Context selection (which documents to include)
+- Compaction strategies
+
+### Single Variable Testing
+
+Change ONE thing at a time. If you change both the system prompt AND the examples, you can't attribute improvement to either change.
+
+| Round | Change | Measure |
+|---|---|---|
+| 1 | Add XML structure to prompt | Consistency, format compliance |
+| 2 | Add 3 multishot examples | Accuracy, edge case handling |
+| 3 | Raise system prompt altitude | Generalization, brevity |
+| 4 | Add retrieval for context | Accuracy, completeness |
+
+**Sample size matters.** Test on 20+ inputs to distinguish real improvement from noise. Record results for each round:
+
+```
+Round: 3
+Change: Replaced step-by-step instructions with principles
+Baseline: Accuracy 4.2, Completeness 3.8, Relevance 3.5
+Variant:  Accuracy 4.0, Completeness 3.6, Relevance 4.1
+Decision: Keep — relevance improved; add examples to recover completeness
+```
+
+---
+
+## Memory Metrics
+
+### Precision and Recall
+- **Precision**: Of the memories retrieved, how many were actually relevant?
+  - Low precision = noisy retrieval, irrelevant context injected
+  - Fix: Better embedding model, stricter similarity thresholds, re-ranking
+
+- **Recall**: Of the relevant memories that exist, how many were retrieved?
+  - Low recall = useful memories missed
+  - Fix: Better query formulation, lower similarity thresholds, multiple search strategies
+
+### Recall@K
+- Of the relevant memories, how many appear in the top K results?
+- Recall@5 is most important — agents rarely use more than 5 retrieved items effectively
+- Target: Recall@5 > 0.7 for your most common query types
+
+### Memory Quality Indicators
+
+| Metric | Healthy Range | Warning Sign |
+|---|---|---|
+| Active observations | Growing slowly | Explosive growth (>50/week) = low quality |
+| Resolution rate | 10-20% per month | 0% = never maintaining, >50% = storing too much trivia |
+| Retrieval relevance | >70% relevant in top 5 | <50% = classification or embedding problems |
+| Memory types distribution | Mix of all types | 90%+ one type = narrow capture |
+| Duplicate rate | <5% | >10% = not searching before storing |
+
+---
+
+## Iterative Improvement Workflow
+
+### The Feedback Loop
+
+```
+1. Identify a failure mode (wrong output, missed info, hallucination)
+   |
+   v
+2. Diagnose root cause (bad prompt? missing context? wrong retrieval?)
+   |
+   v
+3. Hypothesize fix (raise altitude? add examples? improve retrieval?)
+   |
+   v
+4. Apply ONE change
+   |
+   v
+5. Test on the original failure case + 5-10 similar cases
+   |
+   v
+6. Did it improve without regressing other cases?
+   |-- Yes -> Keep change, go to step 1 with next failure mode
+   |-- No  -> Revert change, try different hypothesis (step 3)
+```
+
+### Failure Mode to Root Cause Mapping
+
+| Failure Mode | Likely Root Cause | First Fix to Try |
+|---|---|---|
+| Model ignores instructions | Context too long, instructions buried | Compress context, move instructions to system prompt start |
+| Inconsistent output format | No examples of expected format | Add 3 multishot examples with exact output format |
+| Hallucinated information | Model lacking context it needs | Add retrieval (RAG) for the missing knowledge |
+| Correct but verbose | No conciseness instruction | Add explicit length/brevity constraint |
+| Handles common cases, fails edge cases | Examples only show happy path | Add edge case examples (2-3 tricky inputs) |
+| Works for simple queries, fails complex | Single-shot overload | Chain into multiple steps, add CoT |
+| Uses wrong tool | Tool descriptions overlap | Rewrite descriptions to be mutually exclusive |
+| Starts strong, degrades over time | Context rot | Add compaction at 60% capacity, repeat key instructions |
+| Different result each time | Underdetermined prompt | Add more constraints, examples, or structured output format |
+
+Prioritize fixes by **frequency** (how often it occurs), **severity** (how bad the outcome is), and **fixability** (can you address the root cause?). Fix high-frequency, high-severity issues first.
+
+---
+
+## Common Failure Modes
+
+| Failure Mode | Symptom | Category | Remedy |
+|---|---|---|---|
+| Prompt injection | Model ignores system prompt | Security | Input sanitization, separate user/system context |
+| Context overflow | Truncated or missing information | Capacity | Compress, isolate, select less |
+| Stale retrieval | Outdated information surfaces | Memory | Resolve/supersede old observations, refresh index |
+| Over-retrieval | Too many results injected | Selection | Stricter top-K, re-ranking |
+| Under-retrieval | Relevant information not found | Selection | Better embeddings, query expansion |
+| Goal drift | Agent forgets original task | Session | Goal scratchpad, periodic restatement |
+| Tool abuse | Model calls tools unnecessarily | Selection | Fewer tools, clearer descriptions |
+| Format drift | Output format degrades over conversation | Compression | Repeat format instructions after compaction |
+| Anchor bias | First example dominates outputs | Examples | Diverse examples, put the "typical" case second |
+| Sycophancy | Model agrees with incorrect user statements | System prompt | Add "push back when the user is wrong" instruction |
+
+---
+
+## Testing Checklist
+
+Before deploying a prompt/context configuration:
+
+- [ ] Tested on 10+ diverse inputs (not just the examples used in the prompt)
+- [ ] Edge cases covered: empty input, very long input, ambiguous input, off-topic input
+- [ ] Output format consistent across all test cases
+- [ ] No hallucinated information in any test output
+- [ ] Performance acceptable within token/cost budget
+- [ ] Compaction tested: still works after 20+ turns of conversation
+- [ ] Retrieval tested: correct memories/documents surface for test queries
+- [ ] Negative testing: model correctly refuses out-of-scope requests

--- a/.cursor/skills/context-engineering/references/memory-and-sessions.md
+++ b/.cursor/skills/context-engineering/references/memory-and-sessions.md
@@ -1,0 +1,244 @@
+# Memory and Sessions
+
+This reference covers how to use memory effectively in agent-assisted development: the three memory types, how to extract and consolidate knowledge, provenance tracking, and practical patterns for OAK CI's memory tools.
+
+---
+
+## Memory Types
+
+### Episodic Memory (What Happened)
+
+Records of specific events, experiences, and outcomes. Time-stamped, contextual, narrative — answers "what happened last time?"
+
+- Tied to a specific moment and context
+- Includes cause, effect, and resolution
+- Most valuable when recent; decays in relevance over time
+- Forms raw material for semantic memory through consolidation
+
+**Examples:**
+- "Refactoring broke auth tests — circular imports between `auth_service.py` and `user_service.py`"
+- "Customer API returned 429s after batch size increased to 100 — dropped to 50"
+
+**OAK CI mapping:** Observations with type `bug_fix` or `gotcha`
+
+### Procedural Memory (How To Do Things)
+
+Skills, workflows, and step-by-step processes. Relatively stable — changes slowly as best practices evolve.
+
+- Describes a sequence of actions to achieve a goal
+- Codified in documentation, runbooks, or constitutions
+- Most valuable when accurate and current
+
+**Examples:**
+- "To add a new API endpoint: create route, add service method, write tests, update docs"
+- "To add a new OAK feature: create manifest.yaml, implement RFC, add commands, register in feature service"
+
+**OAK CI mapping:** Constitutions (`oak/constitution.md`), skill files, golden paths. Procedural memory lives in structured documents rather than individual observations.
+
+### Semantic Memory (Facts and Concepts)
+
+General knowledge about the domain, codebase, or system. Context-independent — true regardless of when or how it was learned.
+
+- Factual, declarative knowledge
+- Stable until the underlying reality changes
+- Provides context without requiring the full history
+
+**Examples:**
+- "This project uses PostgreSQL 15 with read replicas for reporting queries"
+- "We chose event sourcing for the order system to support audit requirements"
+
+**OAK CI mapping:** Observations with type `discovery`, `decision`, or `trade_off`
+
+### Memory Type Selection Guide
+
+| You want to remember... | Memory Type | OAK CI Type |
+|---|---|---|
+| A bug you fixed and why | Episodic | `bug_fix` |
+| A non-obvious behavior | Episodic | `gotcha` |
+| How to deploy the app | Procedural | Constitution/Skill |
+| An architectural decision | Semantic | `decision` |
+| A pattern you discovered | Semantic | `discovery` |
+| A trade-off you accepted | Semantic | `trade_off` |
+
+**Rule of thumb:** If it happened once and the specifics matter, it is episodic. If it is always true (until something changes), it is semantic. If it describes how to do something, it is procedural.
+
+---
+
+## Memory Extraction Pipeline
+
+Raw experience becomes useful memory through four stages: capture, classify, consolidate, retrieve.
+
+### 1. Capture (During Work)
+
+Record observations as they happen — context and detail fade quickly. Capture surprising behavior, root causes (not symptoms), decisions with rationale, and codebase discoveries.
+
+```bash
+# Good — specific, includes file path and root cause
+oak ci remember "Auth middleware silently swallows ConnectionError — returns 200 instead of 503. Bare except on line 47" --type gotcha --context src/middleware/auth.py
+
+# Bad — vague, no actionable detail
+oak ci remember "Auth has a bug" --type gotcha
+```
+
+**Every observation should include:** what happened, where it applies (file paths), and why it matters.
+
+### 2. Classify
+
+Assign a type based on what kind of knowledge the observation represents.
+
+| Observation is about... | Classify as |
+|---|---|
+| Something that broke and how you fixed it | `bug_fix` |
+| A non-obvious behavior that could trip someone up | `gotcha` |
+| A fact about the system or domain | `discovery` |
+| A choice you made and why | `decision` |
+| A compromise with known downsides | `trade_off` |
+
+### 3. Consolidate
+
+Individual episodic memories should consolidate into semantic knowledge over time — specific events become general understanding.
+
+**Example:** Three separate gotchas about parallel test failures (shared session state, shared mock gateway, shared email queue) consolidate into one decision: "Integration tests using shared external state must use the `isolated_services` fixture."
+
+```bash
+# Create the consolidated observation
+oak ci remember "Integration tests with shared external state must use isolated_services fixture" --type decision --context tests/conftest.py
+
+# Resolve the observations it replaces
+oak ci resolve <uuid-1> --status superseded
+oak ci resolve <uuid-2> --status superseded
+```
+
+**When to consolidate:** Three or more observations about the same topic, or a pattern has emerged from individual incidents.
+
+### 4. Retrieve
+
+Pull relevant memories when starting new work.
+
+```bash
+# Automatic context assembly — curated code + memories based on task and files
+oak ci context "refactoring the auth service" -f src/services/auth.py
+
+# Targeted search by type
+oak ci search "auth import issues" --type memory
+oak ci search "rate limiting" --type all
+```
+
+---
+
+## Provenance Tracking
+
+Every memory should answer: who learned this, when, and from what evidence?
+
+### Why Provenance Matters
+
+Stale memories are worse than no memories — they actively mislead. An observation saying "the users table has no index on email" causes agents to work around a problem that was fixed last week. Provenance (when recorded, what code referenced) lets you detect and resolve staleness.
+
+### OAK CI Provenance Fields
+
+| Field | What it records |
+|---|---|
+| `session_id` | Which session created the observation |
+| `created_at_epoch` | When it was created (Unix timestamp) |
+| `context` | File path or additional context linking to code |
+| `session_origin_type` | Planning, investigation, or implementation |
+| `resolved_by_session_id` | Which session marked it resolved |
+| `resolved_at` | When it was resolved |
+
+### Provenance Best Practices
+
+**Include file paths in the context field.** Ties memory to code, enabling staleness detection when code changes.
+
+```bash
+# Good — tied to specific code
+oak ci remember "Rate limiter uses fixed window, not sliding — burst at window boundaries" --type discovery --context src/middleware/rate_limiter.py
+
+# Weak — floating, hard to verify later
+oak ci remember "Rate limiter has a burst problem" --type discovery
+```
+
+**Include error messages and specific details** for searchability. **Record session type** — implementation observations (tested and verified) carry more weight than planning observations (potentially speculative).
+
+---
+
+## Memory-as-a-Tool Pattern
+
+Instead of holding everything in the context window, treat memory as an external tool queried on demand.
+
+### The Workflow
+
+```
+Agent receives task -> searches memory -> gets relevant results -> uses in current work -> stores new learnings -> future sessions benefit
+```
+
+**Benefits:** Context window stays focused on the current task. Memory accumulates across sessions. Each retrieval is targeted. Knowledge persists beyond session boundaries and is shared across agents.
+
+### OAK CI Commands
+
+**Store** during work:
+```bash
+oak ci remember "Billing API rate limits at 100 req/min — returns 429 with Retry-After" --type discovery
+```
+
+**Retrieve** when starting work:
+```bash
+oak ci search "billing API rate limits" --type memory
+oak ci context "refactoring the auth service" -f src/services/auth.py
+```
+
+**Resolve** when memory becomes stale:
+```bash
+oak ci resolve <uuid> --reason "Refactored to eliminate circular dependency"
+oak ci resolve <uuid> --status superseded --reason "Replaced by event-driven architecture"
+```
+
+---
+
+## Session Memory Patterns
+
+### Session Summaries
+
+At session end, generate a summary: what was accomplished, what was learned, what remains. OAK CI stores these as `session_summary` observations, creating episodic memories for future sessions.
+
+**A good session summary includes:**
+- Tasks completed (with file paths)
+- Decisions made and their rationale
+- Open questions or unfinished work
+- Observations stored during the session
+
+### Cross-Session Context
+
+Retrieve relevant context from past sessions when starting new work:
+
+```bash
+oak ci context "continuing the auth refactor" -f src/services/auth.py -f src/services/user.py
+```
+
+This returns relevant memories (including past session summaries) alongside related code, providing continuity without full conversation history.
+
+### Memory Decay and Maintenance
+
+Not all memories stay relevant. Active maintenance prevents memory rot. Resolve observations when: the referenced code was refactored or deleted, the decision was reversed, the gotcha was fixed, or newer observations cover the same ground better.
+
+| Situation | Action |
+|---|---|
+| Bug was fixed | Resolve the `bug_fix` observation |
+| Gotcha no longer applies | Resolve the `gotcha` observation |
+| Decision was reversed | Mark `superseded`, create new decision |
+| Observations overlap | Consolidate into one, resolve the rest |
+| Code was deleted | Resolve related observations |
+
+---
+
+## Common Memory Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|---|---|---|
+| Storing everything | Bloat, poor retrieval — important observations buried in noise | Be selective: only store what would help a future session |
+| Vague observations | "Auth was broken" — useless for retrieval, no actionable guidance | Include specifics: error messages, file paths, root cause |
+| Never resolving | Stale memories mislead sessions into working around fixed problems | Resolve observations after addressing the issue |
+| No context field | Memory disconnected from code, cannot validate against current state | Always include file paths or module names |
+| Duplicate observations | Same insight stored multiple times degrades precision | Search before storing; consolidate duplicates |
+| Session-only memory | Knowledge lost when session ends | Use persistent memory for learnings worth keeping |
+| Over-consolidation | Premature generalization loses nuance from specific incidents | Wait for three or more instances before generalizing |
+| No provenance | Cannot assess validity; no way to trace back to evidence | Include file paths, timestamps, and specific details |

--- a/.cursor/skills/context-engineering/references/prompt-foundations.md
+++ b/.cursor/skills/context-engineering/references/prompt-foundations.md
@@ -1,0 +1,322 @@
+# Prompt Engineering Foundations
+
+Eight core techniques for writing effective prompts. Each section covers: what it is, when to use it, how to apply it, a concrete example, and common mistakes.
+
+---
+
+## 1. Be Clear and Direct
+
+Specificity eliminates ambiguity. Tell the model exactly what you want — format, length, style, and constraints.
+
+**How to apply:**
+- State the task, format, and constraints up front
+- Use imperative verbs: "List", "Analyze", "Write", "Compare"
+- Specify exclusions when they matter
+- Define success criteria
+
+**Example — bad vs good:**
+
+```
+Bad:  Review this code.
+
+Good: Review this Python function for:
+      1. Security vulnerabilities (injection, XSS)
+      2. Performance issues (N+1 queries, unnecessary allocations)
+      3. Correctness bugs (off-by-one, null handling)
+
+      For each issue: line number, severity (critical/warning/info),
+      and corrected code. If none found, say "None found."
+```
+
+**Mistakes:** Assuming the model infers format preferences. Using vague qualifiers ("good", "comprehensive") without defining them. Omitting constraints then being surprised by the output shape.
+
+---
+
+## 2. Use Examples (Multishot Prompting)
+
+Provide 3-5 input-output examples demonstrating the pattern you want. Examples are the most reliable way to specify format, tone, and edge case handling.
+
+**How to apply:**
+- 3-5 examples minimum (one or two won't establish a pattern)
+- Vary them: happy path, edge cases, boundary conditions, negative cases
+- Show exact input-output structure
+- Order simple to complex
+
+**Example:**
+
+```xml
+Classify each customer message into exactly one category.
+
+<examples>
+<example>
+<input>I can't log in even with the right password</input>
+<output>category: authentication | priority: high</output>
+</example>
+<example>
+<input>How much does the enterprise plan cost?</input>
+<output>category: billing | priority: low</output>
+</example>
+<example>
+<input>Your product crashed during my presentation!!!</input>
+<output>category: bug-report | priority: critical</output>
+</example>
+<example>
+<input></input>
+<output>category: invalid | priority: none</output>
+</example>
+</examples>
+
+Now classify: <input>{{MESSAGE}}</input>
+```
+
+The last example teaches the model how to handle malformed input rather than leaving it to guess.
+
+**Mistakes:** Only showing happy-path examples. Examples too similar to each other. Inconsistent formatting across examples (the model mirrors inconsistency).
+
+---
+
+## 3. Chain of Thought (CoT)
+
+Instruct the model to reason step by step before answering. Dramatically improves accuracy on logic, math, and multi-step analysis.
+
+**Three levels:**
+
+**Basic** — add "Think step by step." Simple, effective for straightforward reasoning.
+
+**Guided** — provide numbered steps when the reasoning process matters:
+```
+Determine if this function has a bug:
+1. Identify what it should do from name and docstring
+2. Trace logic with a normal input
+3. Trace with edge cases (empty, null, boundary)
+4. Compare actual vs expected behavior
+5. Conclude: bug or no bug, with evidence
+```
+
+**Structured** — wrap reasoning in tags to separate thinking from output:
+```xml
+Analyze whether this migration is safe for production.
+
+Work through your analysis inside <reasoning> tags, then give your
+verdict inside <verdict> tags. Consider: table locks, reversibility,
+data backfill volume, partial failure scenarios.
+```
+
+| Level | Use when |
+|---|---|
+| Basic | Simple math, single-step deductions |
+| Guided | Multi-step debugging, analysis where process matters |
+| Structured | Complex decisions, when downstream systems consume the reasoning |
+
+**Mistakes:** Using CoT for simple factual lookups (adds latency, no accuracy gain). Over-constraining the thinking format. Asking for "just the answer" on hard problems.
+
+---
+
+## 4. Use XML Tags for Structure
+
+Claude treats XML tags as first-class structural elements — the most reliable way to separate context, instructions, examples, and output format.
+
+**When to use:** Any prompt with more than one logical section, when mixing data with instructions, when specifying output format.
+
+**Example:**
+```xml
+<context>
+Debugging a failing test suite. Project: Python 3.12, pytest.
+</context>
+
+<test_output>
+FAILED test_auth.py::test_login_redirect - expected 302, got 200
+FAILED test_auth.py::test_expired_token - connection pool exhausted
+</test_output>
+
+<instructions>
+For each failure: identify root cause, determine if related, suggest fix.
+</instructions>
+
+<output_format>
+## [test name]
+**Root cause:** [one sentence]
+**Related:** [yes/no and why]
+**Fix:** [code block]
+</output_format>
+```
+
+**Nesting** for hierarchy (two levels is usually sufficient):
+```xml
+<documents>
+  <document id="1" title="API Spec">...content...</document>
+  <document id="2" title="Error Logs">...content...</document>
+</documents>
+```
+
+**Mistakes:** Generic tag names (`<data>`) instead of specific ones (`<error_log>`). Over-nesting beyond two levels. Mixing XML tags with markdown headers for the same purpose.
+
+---
+
+## 5. Give Claude a Role (System Prompts)
+
+The system prompt establishes persistent behavioral context — role, constraints, and output conventions that frame every response.
+
+**How to apply:**
+- Define role, expertise, and boundaries
+- Set the right altitude: specific enough to be useful, general enough for varied inputs
+- Include what to do when uncertain
+
+**Example — bad vs good:**
+
+```
+Bad:  You are a helpful coding assistant. Be thorough and accurate.
+```
+"Helpful" and "thorough" are not actionable — they contain no specific guidance.
+
+```xml
+Good:
+<role>
+Senior backend engineer. Python + PostgreSQL.
+Production system handling financial transactions.
+</role>
+
+<constraints>
+- Never sacrifice data consistency for performance
+- Flag non-idempotent operations
+- When unsure, say "I'm not confident because..." rather than guessing
+</constraints>
+
+<output_conventions>
+- Python type hints in all code examples
+- Include error handling (no happy-path-only code)
+- Reference specific line numbers when reviewing
+</output_conventions>
+```
+
+**Mistakes:** System prompt so long it dilutes the important parts. Only negative instructions ("don't do X") without positive guidance. Role too narrow, causing refusals on legitimate requests.
+
+---
+
+## 6. Chain Complex Prompts
+
+Break complex tasks into sequential steps where output of step N feeds step N+1. Better results than asking for everything at once.
+
+**When to use:** Tasks with distinct phases (research, analyze, synthesize). When quality at each step matters. When different steps need different instructions.
+
+**Example pipeline:**
+```
+Step 1 (Extract):  "Extract all function signatures and docstrings."
+Step 2 (Analyze):  "For each function, identify missing error handling,
+                    unused params, unclear naming. Rate severity."
+Step 3 (Synthesize): "Group by severity. Write corrected code for
+                      critical/warning issues. Summarize in a table."
+```
+
+**Gate outputs between steps** — validate before passing forward:
+```python
+extracted = call_model(step_1_prompt, document)
+
+# Gate: verify extraction produced results
+if not extracted.functions:
+    raise ValueError("Extraction empty — check input format")
+
+analysis = call_model(step_2_prompt, extracted)
+```
+
+**Mistakes:** Passing too much context between steps (carry only what the next step needs). Not validating intermediates. Steps too granular (each should do meaningful work).
+
+---
+
+## 7. Long Context Window Tips
+
+Position and organization of information in the context window significantly affects output quality. The "lost in the middle" effect means information buried in the center of very long contexts gets less attention.
+
+**Key techniques:**
+
+**Front-load and repeat critical instructions:**
+```xml
+<instructions>
+<!-- FIRST: anchor behavior -->
+Find all security vulnerabilities. Focus on injection, auth bypass, data exposure.
+</instructions>
+
+<codebase>
+...thousands of lines...
+</codebase>
+
+<reminder>
+<!-- LAST: reinforce -->
+Focus only on security vulnerabilities.
+Format: file, line, type, severity, fix.
+</reminder>
+```
+
+**Tag-delineate sections** when including multiple documents:
+```xml
+<documents>
+  <document title="Auth Module" path="src/auth.py">...code...</document>
+  <document title="Schema" path="schema.sql">...schema...</document>
+</documents>
+```
+
+**Include retrieval hints** for very long contexts: "Find the users table in the Schema document and check for a unique constraint on email."
+
+**Order by relevance:** most relevant documents first. For bug analysis: error/stack trace, then source file, then config, then tests, then docs.
+
+**Mistakes:** Dumping context without structure. Critical instructions only in the middle. Including irrelevant context "just in case" (dilutes attention).
+
+---
+
+## 8. Extended Thinking
+
+Extended thinking allocates dedicated tokens for the model to reason internally before producing a visible response. Unlike CoT, this happens in a separate, larger thinking space and can use significantly more tokens.
+
+**When to use:**
+- Complex math or proofs
+- Multi-file code analysis with component interactions
+- Architecture decisions with many tradeoffs
+- Debugging where root cause is non-obvious
+
+**When NOT to use:** Simple factual questions, straightforward code generation, tasks where speed matters more than depth.
+
+**How to apply:**
+
+Set thinking budget based on complexity: small for simple debugging, large for architecture review or multi-step planning.
+
+Let the model reason freely — don't constrain thinking format:
+```
+Good: "Analyze this distributed system for consistency issues.
+       Think deeply about edge cases before responding."
+
+Bad:  "In your thinking, first list all components, then draw
+       arrows between them, then..."
+```
+
+Specify what to *produce*, not how to *think*. Combine with structured output:
+```xml
+<task>
+Review this migration plan. Consider data integrity, rollback safety,
+and performance impact on a 50M-row table.
+</task>
+
+<output_format>
+1. GO / NO-GO recommendation
+2. Risk summary (one paragraph)
+3. Required changes before deploy (bulleted list)
+</output_format>
+```
+
+**Mistakes:** Enabling for every prompt (wastes tokens on simple tasks). Controlling the thinking format. Using thinking as substitute for providing good context.
+
+---
+
+## Anti-Patterns Reference
+
+| Anti-Pattern | Why It Fails | Fix |
+|---|---|---|
+| "Be helpful" | Too vague, no actionable guidance | Specify exact behavior, constraints, output format |
+| Contradictory instructions | Model picks one unpredictably | Resolve conflicts; prioritize with "IMPORTANT" |
+| Wall of text prompt | Key info buried, position bias | Structure with XML; front-load critical info |
+| No examples | Model guesses output format | Add 3-5 diverse multishot examples |
+| "Do everything at once" | Exceeds single-prompt capacity | Chain into sequential steps with gates |
+| Overly rigid templates | Brittle to edge cases | Define principles and show examples instead |
+| "Don't do X" (only negatives) | Model attention anchors on X | State what TO do instead |
+| Expecting one-shot perfection | Unrealistic for complex tasks | Iterate: test varied inputs, refine on failures |
+| Kitchen-sink system prompt | Dilutes important instructions | Keep focused: role, constraints, output conventions |
+| No output validation | Hallucinations and drift undetected | Validate between chained steps |

--- a/.cursor/skills/context-engineering/references/system-prompt-design.md
+++ b/.cursor/skills/context-engineering/references/system-prompt-design.md
@@ -1,0 +1,237 @@
+# System Prompt Design
+
+System prompts define who the model is, what it should do, and how it should behave. This reference covers effective system prompt anatomy, writing instructions at the right abstraction level, Claude-specific patterns, and annotated templates.
+
+---
+
+## System Prompt Anatomy
+
+Every effective system prompt has five components, in this order. Ordering matters — models give more weight to content that appears earlier.
+
+### 1. Role and Identity
+
+One or two sentences establishing domain expertise. Sets tone, vocabulary, and decision-making framework.
+
+```
+You are a senior backend engineer specializing in distributed systems.
+```
+
+Be specific enough to shape behavior, broad enough to handle varied inputs. Avoid character fiction ("Dr. Sarah Chen, known for dry wit") — it dilutes technical focus. Avoid generics ("You are a helpful assistant") — it changes nothing.
+
+### 2. Core Constraints
+
+Hard rules the model must always follow. Put these BEFORE task instructions — models respect early constraints more reliably. Use RFC 2119 language (MUST, MUST NOT, SHOULD, MAY) for clarity.
+
+```xml
+<constraints>
+- You MUST NOT modify database schema without explicit approval
+- You MUST cite specific file and line numbers when identifying issues
+- You SHOULD prefer backward-compatible solutions
+- When uncertain, ask for clarification rather than guessing
+</constraints>
+```
+
+The last line is critical — every system prompt should define what the model does when unsure. Without it, the model either guesses (risky) or refuses (unhelpful).
+
+### 3. Task Instructions
+
+What the model should do. Write at the right "altitude" — principles over procedures (see the Altitude Scale below).
+
+```xml
+<instructions>
+When reviewing code, focus on correctness and security over style.
+Flag potential issues but do not rewrite working code for aesthetic reasons.
+When multiple approaches exist, explain the tradeoffs and recommend one.
+</instructions>
+```
+
+Good task instructions answer: What is the primary objective? What gets prioritized when objectives conflict? What does "done" look like?
+
+### 4. Output Format
+
+Be explicit — the model won't consistently infer format preferences.
+
+```xml
+<output_format>
+Respond with a JSON object:
+{
+  "summary": "One-sentence assessment",
+  "issues": [{"severity": "critical|warning|info", "file": "path", "line": 42, "description": "...", "suggestion": "..."}],
+  "overall_rating": "approve | request-changes | needs-discussion"
+}
+</output_format>
+```
+
+If you want markdown, say so. If you want JSON, provide the schema. Ambiguity here is the most common source of format drift.
+
+### 5. Canonical Examples
+
+Two to three input-output pairs demonstrating ideal behavior. Examples anchor behavior more reliably than instructions alone. Show range (positive and negative cases) and edge cases.
+
+```xml
+<example>
+<input>
+def get_user(id):
+    query = f"SELECT * FROM users WHERE id = {id}"
+    return db.execute(query)
+</input>
+<output>
+**Critical: SQL Injection** — line 2 uses f-string with user input.
+Fix: `db.execute("SELECT * FROM users WHERE id = ?", [id])`
+</output>
+</example>
+```
+
+---
+
+## The Altitude Scale
+
+The most common system prompt mistake is writing instructions at the wrong abstraction level.
+
+### Level 1: Ground Level (Too Specific)
+
+```
+Always use 4-space indentation. Variable names must be camelCase.
+Functions must not exceed 20 lines.
+```
+
+Brittle. Doesn't adapt to context. What happens when the codebase uses tabs?
+
+### Level 2: Cruising Altitude (Right Level)
+
+```
+Follow the project's established conventions. Match surrounding
+code style. Prefer clarity over cleverness.
+```
+
+Principled, adaptable. Handles novel situations because it has principles, not just rules.
+
+### Level 3: Stratosphere (Too Vague)
+
+```
+Write good code. Be helpful. Follow best practices.
+```
+
+No actionable guidance. The model falls back to generic behavior.
+
+### Finding Your Altitude
+
+| Domain | Too Low | Right Altitude | Too High |
+|---|---|---|---|
+| Code Review | "Flag if cyclomatic complexity > 10" | "Flag functions hard to understand at a glance" | "Review the code" |
+| Writing | "Sentences must be 12-15 words" | "Write concisely. Prefer short sentences. Cut filler." | "Write well" |
+| Data Analysis | "Use pandas groupby then merge" | "Use efficient operations. Profile before optimizing." | "Analyze the data" |
+| Security Audit | "Check for CVE-2024-1234" | "Identify injection points and trust boundaries" | "Find vulnerabilities" |
+
+**The test:** If your instruction applies regardless of language, framework, or codebase, it's the right altitude.
+
+---
+
+## Claude-Specific Patterns
+
+### XML Tag Conventions
+
+Claude has strong native understanding of XML structure:
+
+- `<context>`, `<instructions>`, `<constraints>`, `<examples>` for top-level sections
+- Nesting up to 2-3 levels: `<examples><example><input>...</input><output>...</output></example></examples>`
+- Attributes for metadata: `<document id="1" title="API Spec" path="src/api.py">`
+- Descriptive tag names — `<error_log>` over `<data>`, `<user_request>` over `<input>`
+- No `<system>` wrapper needed — Claude already knows it's reading a system prompt
+
+### Extended Thinking Integration
+
+Guide the model toward deeper reasoning without constraining its process. Say "Think deeply about edge cases before responding" (good) rather than "First list all components, then draw arrows, then rate each on a 1-5 scale" (bad). Specify what to produce, not how to think.
+
+### Prefilling
+
+Start the assistant's response to anchor output format:
+
+```
+Assistant: {"analysis":
+```
+
+Useful for ensuring JSON output, anchoring structure, or preventing preamble ("Sure! Here's my analysis..."). Use prefilling for format, not for constraining reasoning.
+
+---
+
+## Annotated Templates
+
+### Code Review Agent
+
+```xml
+You are a senior software engineer performing code review.
+
+<constraints>
+- Focus on correctness, security, and maintainability
+- Do NOT rewrite working code for style preferences alone
+- Flag potential bugs with severity: critical, warning, info
+- If uncertain whether something is a bug, say so explicitly
+- MUST NOT approve code with known security vulnerabilities
+</constraints>
+
+<instructions>
+Review the provided code changes. For each issue:
+1. Identify the file and line
+2. Describe the issue and why it matters
+3. Suggest a fix
+
+After reviewing, provide a summary assessment.
+If no issues are found, say so — do not fabricate issues.
+</instructions>
+```
+
+Constraints before instructions, "do not fabricate" prevents false positives, severity levels in constraints keep output consistent.
+
+### Research Assistant
+
+```xml
+You are a research assistant analyzing documents and synthesizing findings.
+
+<constraints>
+- Cite sources with specific quotes or page references
+- Distinguish facts in documents from your inferences
+- If asked about something not in the documents, say so clearly
+- MUST NOT fabricate citations or references
+</constraints>
+
+<instructions>
+Analyze provided documents: identify themes, note contradictions between
+sources, synthesize findings. Use <finding> tags with source attribution.
+</instructions>
+
+<output_format>
+<finding source="Document Title, p. X">
+[Insight with direct quote or specific reference]
+</finding>
+</output_format>
+```
+
+MUST NOT on fabricated citations addresses the highest-risk failure mode. Distinguishing facts from inferences prevents the model from presenting reasoning as source material.
+
+### Data Analysis Agent
+
+```xml
+You are a data analyst working with structured datasets.
+
+<constraints>
+- Show methodology before results
+- Validate data quality before analysis (nulls, duplicates, outliers)
+- State assumptions explicitly
+- Do not over-interpret small samples (note when n < 30)
+</constraints>
+
+<instructions>
+For each analysis: understand the question, examine data quality,
+choose and explain the method, present findings with caveats.
+Prefer tables over prose for numerical results.
+</instructions>
+```
+
+Methodology-before-results prevents jumping to conclusions. Concrete threshold (n < 30) instead of vague "be careful."
+
+---
+
+## Cross-Reference
+
+See also: The `/project-governance` skill for creating and maintaining project constitutions and agent rules files — these are system prompts implemented as version-controlled documents.

--- a/.cursor/skills/project-governance/SKILL.md
+++ b/.cursor/skills/project-governance/SKILL.md
@@ -68,6 +68,7 @@ oak rules detect-existing      # Discover all configured agent instruction files
 - **Creating CLAUDE.md, AGENTS.md, or .cursorrules** for a new project
 - **Proposing a new feature** that needs team review (RFC)
 - **Making architectural decisions** that should be documented (ADR)
+- **Learning context engineering theory** behind effective rule writing -- see `/context-engineering` for the altitude concept, canonical examples, and structured context patterns
 - **Reviewing an RFC** for completeness and technical soundness
 
 ## Constitution Structure

--- a/.github/skills/codebase-intelligence/SKILL.md
+++ b/.github/skills/codebase-intelligence/SKILL.md
@@ -124,7 +124,7 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "YOUR QUERY HERE"
 | Table | Purpose | Key Columns |
 |-------|---------|-------------|
 | `memory_observations` | Extracted memories/learnings | `observation`, `memory_type`, `status`, `context`, `tags`, `importance`, `session_origin_type` |
-| `sessions` | Coding sessions (launch to exit) | `id`, `agent`, `status`, `summary`, `title`, `started_at`, `created_at_epoch` |
+| `sessions` | Coding sessions (launch to exit) | `id`, `agent`, `status`, `summary`, `title`, `title_manually_edited`, `started_at`, `created_at_epoch` |
 | `prompt_batches` | User prompts within sessions | `session_id`, `user_prompt`, `classification`, `response_summary` |
 | `activities` | Raw tool executions | `session_id`, `tool_name`, `file_path`, `success`, `error_message` |
 | `agent_runs` | CI agent executions | `agent_name`, `task`, `status`, `result`, `cost_usd`, `turns_used` |

--- a/.github/skills/codebase-intelligence/SKILL.md
+++ b/.github/skills/codebase-intelligence/SKILL.md
@@ -130,7 +130,7 @@ sqlite3 -readonly -header -column .oak/ci/activities.db "YOUR QUERY HERE"
 | `agent_runs` | CI agent executions | `agent_name`, `task`, `status`, `result`, `cost_usd`, `turns_used` |
 | `session_link_events` | Session linking analytics | `session_id`, `event_type`, `old_parent_id`, `new_parent_id` |
 | `session_relationships` | Semantic session relationships | `session_a_id`, `session_b_id`, `relationship_type`, `similarity_score` |
-| `agent_schedules` | Cron scheduling state | `task_name`, `cron_expression`, `enabled`, `last_run_at`, `next_run_at` |
+| `agent_schedules` | Cron scheduling state | `task_name`, `cron_expression`, `enabled`, `additional_prompt`, `last_run_at`, `next_run_at` |
 | `resolution_events` | Cross-machine resolution propagation | `observation_id`, `action`, `source_machine_id`, `applied`, `content_hash` |
 <!-- END GENERATED CORE TABLES -->
 

--- a/.github/skills/codebase-intelligence/references/schema.md
+++ b/.github/skills/codebase-intelligence/references/schema.md
@@ -2,7 +2,7 @@
 
 Complete DDL for the Oak CI SQLite database at `.oak/ci/activities.db`.
 
-Current schema version: **4**
+Current schema version: **6**
 
 ## memory_observations
 
@@ -53,11 +53,14 @@ CREATE TABLE IF NOT EXISTS sessions (
     processed BOOLEAN DEFAULT FALSE,  -- Has background processor handled this?
     summary TEXT,  -- LLM-generated session summary
     title TEXT,  -- LLM-generated short session title (10-20 words)
+    title_manually_edited BOOLEAN DEFAULT FALSE,  -- Protect manual edits from LLM overwrite
     created_at_epoch INTEGER NOT NULL,
     parent_session_id TEXT,  -- Session this was derived from
     parent_session_reason TEXT,  -- Why linked: 'clear', 'compact', 'inferred'
     source_machine_id TEXT,  -- Machine that originated this record
-    transcript_path TEXT  -- Path to session transcript file for recovery
+    transcript_path TEXT,  -- Path to session transcript file for recovery
+    summary_updated_at INTEGER,  -- Epoch when summary was last generated/updated
+    summary_embedded INTEGER DEFAULT 0  -- Has summary been indexed in ChromaDB?
 );
 ```
 

--- a/.github/skills/codebase-intelligence/references/schema.md
+++ b/.github/skills/codebase-intelligence/references/schema.md
@@ -2,7 +2,7 @@
 
 Complete DDL for the Oak CI SQLite database at `.oak/ci/activities.db`.
 
-Current schema version: **3**
+Current schema version: **4**
 
 ## memory_observations
 
@@ -228,6 +228,7 @@ CREATE TABLE IF NOT EXISTS agent_schedules (
     cron_expression TEXT,           -- Cron expression (e.g., '0 0 * * MON')
     description TEXT,               -- Human-readable schedule description
     trigger_type TEXT DEFAULT 'cron', -- 'cron' or 'manual' (future: 'git_commit', 'file_change')
+    additional_prompt TEXT,          -- Persistent assignment prepended to task on each run
 
     -- Runtime state
     last_run_at TEXT,

--- a/.github/skills/context-engineering/SKILL.md
+++ b/.github/skills/context-engineering/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: context-engineering
+description: >-
+  Design effective prompts and optimize context for AI models and agents.
+  Covers prompt engineering foundations (clarity, examples, chain of thought,
+  XML structure), the four context engineering strategies (Write, Select,
+  Compress, Isolate), agent memory and session patterns, and before/after
+  examples showing measurable improvement. Use when writing system prompts,
+  designing agent workflows, optimizing context windows, building prompt
+  templates, structuring few-shot examples, reducing context rot, or
+  improving AI output quality.
+allowed-tools: Read
+user-invocable: true
+---
+
+# Context Engineering
+
+Design effective prompts and optimize the full context window for AI models and agents to produce consistently high-quality output.
+
+## Quick Start
+
+### Recipe 1: Improve a vague prompt
+
+**Before:** `Review this code and give feedback.`
+
+**After:**
+```xml
+<task>Review the provided code for correctness, performance, and maintainability.</task>
+<output-format>
+For each issue: file/line, severity (critical|warning|suggestion), problem (one sentence), fix (concrete code change).
+If no issues, state "No issues found" and list one strength.
+</output-format>
+<code>{{code_to_review}}</code>
+```
+
+**Why it works:** Specifies evaluation criteria, defines output structure, separates instructions from data with XML tags.
+
+### Recipe 2: Design a system prompt
+
+Use the **altitude concept** -- not so high it's useless ("be helpful"), not so low it's brittle ("always use 4 spaces").
+
+1. **Define the role** in one sentence: what the agent IS and IS NOT
+2. **Set altitude** -- right level: "Follow the project's existing naming conventions. When none exists, prefer descriptive names over short ones."
+3. **Add constraints** using RFC 2119 language (MUST, SHOULD, MAY)
+4. **Include 1-2 canonical examples** of ideal output
+5. **Define non-goals** to prevent scope creep
+
+See `references/system-prompt-design.md` for full anatomy and templates.
+
+### Recipe 3: Structure agent context with the 4 strategies
+
+When your agent produces inconsistent or degraded output, apply the four strategies:
+
+| Strategy | Action | Example |
+|----------|--------|---------|
+| **Write** | Craft persistent instructions | System prompt with altitude-appropriate rules |
+| **Select** | Choose what enters context | Use `oak_search` to retrieve only relevant code |
+| **Compress** | Reduce tokens, preserve signal | Summarize prior conversation turns, delegate to sub-agents |
+| **Isolate** | Move information out of context | Store reference docs externally, load just-in-time |
+
+```
+1. Start with Write: define a clear system prompt
+2. Apply Select: give the agent only the tools and context it needs
+3. Add Compress: implement compaction for long sessions
+4. Use Isolate: move large reference material behind retrieval
+```
+
+See `references/context-engineering-framework.md` for the full framework.
+
+## The Evolution: Prompt to Context Engineering
+
+| Level | Focus | Scope | Key Insight |
+|-------|-------|-------|-------------|
+| **Basic Prompting** | The question you type | Single user message | Clarity matters |
+| **Prompt Engineering** | Crafting effective prompts | Prompt + examples + structure | Technique amplifies quality |
+| **Context Engineering** | Everything the model sees | System prompt + tools + memory + retrieved docs + conversation history | The context window IS the product |
+
+Context engineering manages **everything** the model sees -- system prompt, tools, retrieved documents, conversation history, and memory. Every token either helps or hurts. The entire context window is a design surface.
+
+## Prompt Engineering Foundations
+
+These eight techniques form the foundation. Master them before moving to context engineering.
+
+| # | Technique | When to Use | Key Rule |
+|---|-----------|-------------|----------|
+| 1 | **Be clear and direct** | Always -- this is the baseline | State exactly what you want; remove ambiguity |
+| 2 | **Use examples (multishot)** | Output format matters, or the task is nuanced | Show 2-3 examples of ideal input/output pairs |
+| 3 | **Chain of thought** | Reasoning, math, multi-step logic | Ask the model to think step-by-step before answering |
+| 4 | **Use XML tags** | Separating instructions from data, structured output | Wrap distinct sections in descriptive tags like `<context>`, `<instructions>` |
+| 5 | **Give Claude a role** | Specialized tasks needing domain expertise | Set the role in the system prompt, not the user message |
+| 6 | **Chain complex prompts** | Multi-step workflows, pipelines | Break into sequential steps; output of step N feeds step N+1 |
+| 7 | **Long context tips** | Large documents, many files | Put key instructions at top and bottom; use XML to delineate sections |
+| 8 | **Extended thinking** | Complex reasoning, planning, self-correction | Enable thinking to let the model plan before responding |
+
+**Combining techniques:** Most effective prompts use 3-5 techniques together. A code review prompt might combine clarity (#1), XML structure (#4), role (#5), and examples (#2).
+
+See `references/prompt-foundations.md` for detailed explanations, examples, and anti-patterns for each technique.
+
+## Context Engineering Framework (4 Strategies)
+
+### Write: Craft the persistent context
+
+The Write strategy covers everything you author in advance: system prompts, tool descriptions, and instruction files. This is the context you control completely.
+
+**The altitude concept** is the most important principle. Your instructions need to be at the right level of abstraction:
+
+| Altitude | Example | Problem |
+|----------|---------|---------|
+| Too high | "Write clean code" | No actionable guidance -- the agent fills in its own interpretation |
+| Too low | "Always use `Array.prototype.reduce` for aggregation" | Brittle -- breaks when context changes, prevents good judgment |
+| Right | "Prefer declarative patterns over imperative loops. Choose the array method that most clearly expresses intent." | Guides without constraining |
+
+**Canonical examples** are powerful -- a single well-chosen example communicates more than paragraphs of rules:
+
+```xml
+<system>
+You generate API documentation from source code.
+<example>
+<input>
+def calculate_tax(amount: float, rate: float = 0.08) -> float:
+    """Calculate sales tax for a given amount."""
+    return round(amount * rate, 2)
+</input>
+<output>
+### `calculate_tax(amount, rate=0.08)`
+Calculate sales tax for a given amount.
+- `amount` (float): The pre-tax amount
+- `rate` (float, optional): Tax rate as decimal. Default: 0.08
+- **Returns:** float -- Tax amount, rounded to 2 decimal places.
+</output>
+</example>
+</system>
+```
+
+**Project-level Write strategy:** Use the `/project-governance` skill to create a constitution (`oak/constitution.md`) and agent instruction files. Your constitution IS your project-level system prompt. The altitude concept applies directly: "write good code" is useless; "copy `src/features/auth/service.py` for new services" is actionable.
+
+See `references/context-engineering-framework.md` for the full Write strategy guide.
+
+### Select: Choose what enters the context window
+
+Select the right information to include; keep everything else out.
+
+**For tools:** Provide the **minimal viable toolset** (unused tools cause confusion), write **unambiguous descriptions** (the model uses these to decide when to call), and prefer **specific tools** over general-purpose ones.
+
+**For retrieved context:** Quality over quantity (3 relevant snippets beat 20 loose ones), recency matters, and always include source attribution (file paths, line numbers).
+
+**Anti-pattern -- context stuffing:**
+```
+# Bad: dumping everything "just in case"
+context = all_docs + all_code + all_history + all_memories
+# Good: selecting what's relevant
+context = search_relevant_code(task) + get_recent_decisions(task)
+```
+
+### Compress: Reduce tokens while preserving information
+
+Compress rather than truncate. Preserve signal while reducing cost.
+
+**Strategies:** Conversation summarization (replace old turns with structured summary), note-taking scratchpad (running notes vs. re-reading history), sub-agent delegation (offload research, return only findings), and tool result cleanup (extract then clear verbose output).
+
+**When to compress:** Context exceeds 50% capacity, agent forgets earlier instructions, responses repeat or lose focus, or tool results contain mostly irrelevant data.
+
+### Isolate: Move information out of the main context
+
+Store information externally and load just-in-time, rather than keeping it in context at all times.
+
+**Patterns:** Just-in-time retrieval (load docs only when needed), progressive disclosure (summary first, details on demand), hybrid context loading (rules in system prompt, reference material behind search), and memory-as-a-tool (store externally, retrieve on demand).
+
+**Progressive disclosure example:** Agent sees summary ("Auth uses JWT") -> needs details (retrieves auth docs) -> needs code (retrieves auth service file). Each step loads only what's needed.
+
+See `references/context-engineering-framework.md` for the complete framework with extended examples.
+
+## Agent Context Patterns
+
+### Sessions vs memory
+
+| Concept | Scope | Lifetime | Purpose |
+|---------|-------|----------|---------|
+| **Session** | Single conversation | Ephemeral | Working memory for the current task |
+| **Memory** | Cross-session | Persistent | Accumulated knowledge and learnings |
+
+The common mistake: keeping everything in the session instead of writing important things to persistent memory.
+
+### Context rot
+
+Output quality degrades as conversations grow longer due to: **dilution** (instructions buried under tool results), **position bias** (models attend more to beginning/end, losing middle), **contradiction accumulation**, and **working memory overflow**.
+
+**Signs:** Agent forgets earlier constraints, responses become generic/repetitive, re-asks answered questions, quality drops vs. early turns.
+
+**Mitigation:** Apply Compress (summarize and compact) and Isolate (move reference material behind retrieval). For long-running agents, implement periodic compaction checkpoints.
+
+### Memory types
+
+| Type | What It Stores | Example | OAK CI Tool |
+|------|---------------|---------|-------------|
+| **Episodic** | What happened | "Refactored auth module in session #42" | `oak_search --type memory` |
+| **Procedural** | How to do things | "To add a feature, copy the strategic_planning exemplar" | `oak_remember` with type `discovery` |
+| **Semantic** | Facts and concepts | "The API uses JWT tokens with 1-hour expiry" | `oak_remember` with type `discovery` |
+
+### Memory-as-a-tool pattern
+
+Store externally, retrieve on demand -- instead of accumulating in context:
+
+```
+1. Discover → oak_remember("auth tokens expire after 1 hour", type="discovery")
+2. Later   → oak_search("auth token expiry") retrieves just-in-time
+3. Stale   → oak_resolve_memory(id, status="resolved") cleans up
+```
+
+This implements both Compress (don't hold everything) and Isolate (retrieve when needed).
+
+### Compaction strategies
+
+| Strategy | How It Works | Best For |
+|----------|-------------|----------|
+| **Last-N** | Keep only the last N conversation turns | Simple, predictable token budget |
+| **Recursive summarization** | Summarize old turns, keep recent ones verbatim | Long conversations with important early context |
+| **Hybrid** | Summarize + keep pinned messages (system prompt, key decisions) | Complex agents with critical persistent instructions |
+
+See `references/agent-context-patterns.md` and `references/memory-and-sessions.md` for detailed patterns and implementation guidance.
+
+## CI Integration: Context Engineering in Practice
+
+OAK's Codebase Intelligence tools directly implement the four context engineering strategies:
+
+| Strategy | CI Tool | What It Does |
+|----------|---------|--------------|
+| **Write** | `oak_remember` / `oak ci remember` | Persist learnings, decisions, and gotchas to long-term memory |
+| **Select** | `oak_search` / `oak ci search` | Retrieve only the code and memories relevant to the current task |
+| **Isolate** | `oak_context` / `oak ci context` | Assemble just-in-time context for a specific task, pulling from code and memory |
+| **Consolidate** | `oak_resolve_memory` / `oak ci resolve` | Resolve stale observations to prevent context rot in the memory store |
+
+### Example workflow
+
+```bash
+# WRITE: Store a discovery for future sessions
+oak ci remember "Payment service retries 3x with exponential backoff" --type discovery
+# SELECT: Find relevant code for a task
+oak ci search "payment retry logic" --type code -n 5
+# ISOLATE: Assemble just-in-time context
+oak ci context "fix payment timeout bug" -f src/services/payment.py
+# CONSOLIDATE: Clean up after fixing
+oak ci resolve <memory-id>
+```
+
+## Before/After Gallery
+
+### Vague prompt to structured prompt
+
+**Before:** `Write tests for the user service.`
+
+**After:**
+```xml
+<task>Write unit tests for UserService: create_user, get_user_by_email, delete_user.</task>
+<constraints>
+- pytest with fixtures for setup/teardown
+- Test success and error paths for each method
+- Mock external API calls (email verification)
+- Descriptive test names: test_create_user_with_duplicate_email_raises_conflict
+</constraints>
+```
+
+### Bloated system prompt to altitude-optimized
+
+**Before** (micromanaging): "Always use f-strings. Always use pathlib. Always use type hints. Use black with line length 88. Use dataclasses for DTOs. Never use print()..."
+
+**After** (right altitude):
+```xml
+<role>You are a Python developer working in this project.</role>
+<principles>
+- Follow existing patterns. Find the closest implementation and mirror its style.
+- Prefer modern Python (3.10+). When in doubt, check what the codebase uses.
+- Write code that reads clearly without comments. Comment only non-obvious "why" decisions.
+</principles>
+<quality>Run `make check` before considering any change complete.</quality>
+```
+
+### Context-stuffed agent to compress + isolate
+
+**Before:** 40,000 tokens (2K rules + 3K README + 8K tool descriptions + 12K API docs + 15K conversation = half irrelevant)
+
+**After:** 8,000 tokens (800 altitude-optimized prompt + 1,200 for 5 relevant tools + 2,000 retrieved context + 4,000 compressed conversation = all relevant)
+
+See `references/before-after-examples.md` for the full gallery with additional transformations.
+
+## When to Use What
+
+| Situation | Strategy | Key Technique | Reference |
+|-----------|----------|---------------|-----------|
+| Writing a new system prompt | Write | Altitude concept, canonical examples | `references/system-prompt-design.md` |
+| Prompt gives inconsistent results | Foundations | Add examples, use XML structure | `references/prompt-foundations.md` |
+| Agent losing track of goals | Compress | Conversation summarization, compaction | `references/context-engineering-framework.md` |
+| Agent context window filling up | Isolate | Just-in-time retrieval, progressive disclosure | `references/agent-context-patterns.md` |
+| Agent forgetting earlier decisions | Write + Compress | Pin critical context, summarize history | `references/memory-and-sessions.md` |
+| Need to measure prompt quality | Evaluate | A/B testing, rubric scoring | `references/evaluation-and-testing.md` |
+| Setting project-wide AI rules | Write | Constitution as system prompt | `/project-governance` skill |
+| Agent repeating mistakes across sessions | Write | Memory-as-a-tool, `oak_remember` | `references/memory-and-sessions.md` |
+| Complex multi-step reasoning | Foundations | Chain of thought, extended thinking | `references/prompt-foundations.md` |
+| Output format is wrong | Foundations | Examples (multishot), XML tags | `references/prompt-foundations.md` |
+
+## Deep Dives
+
+For detailed guidance on specific topics, consult the reference documents:
+
+- **`references/prompt-foundations.md`** -- Core prompt engineering techniques with examples and anti-patterns
+- **`references/context-engineering-framework.md`** -- The four strategies (Write, Select, Compress, Isolate) in depth
+- **`references/agent-context-patterns.md`** -- Sessions, memory types, context rot, and compaction strategies
+- **`references/system-prompt-design.md`** -- System prompt anatomy, the altitude concept, and reusable templates
+- **`references/memory-and-sessions.md`** -- Memory types, the memory-as-a-tool pattern, and OAK CI integration
+- **`references/before-after-examples.md`** -- Extended gallery of prompt and context transformations
+- **`references/evaluation-and-testing.md`** -- Measuring prompt quality, A/B testing, and iterative improvement

--- a/.github/skills/context-engineering/references/agent-context-patterns.md
+++ b/.github/skills/context-engineering/references/agent-context-patterns.md
@@ -1,0 +1,508 @@
+# Agent Context Patterns
+
+Context management patterns for AI agents: autonomous systems that take actions over multiple turns, read and write files, call tools, and maintain state across interactions. These patterns draw from Google's "Context Engineering: Sessions & Memory" whitepaper by Kimberly Milam & Antonio Gulli, and from production agent architectures.
+
+---
+
+## Sessions vs Memory
+
+Sessions and memory serve fundamentally different roles in agent context. Conflating them leads to either bloated sessions (stuffing everything into the conversation) or amnesia (losing hard-won knowledge between conversations).
+
+| Concept | Sessions | Memory |
+|---|---|---|
+| Lifetime | Single conversation | Across conversations |
+| Scope | Turn-by-turn interaction | Persistent knowledge |
+| Storage | Conversation history (in-context) | External database or file store |
+| Growth | Linear with turns | Curated, relatively stable |
+| Example | Chat messages, tool results | Learned preferences, past decisions, gotchas |
+
+### Session Architecture
+
+Each session is one continuous interaction with a goal. The session context grows with every turn: user message, assistant response, tool calls and their results.
+
+A well-structured session has three phases:
+
+1. **Start**: Goal is established, relevant context is loaded (system prompt, retrieved memories, relevant files).
+2. **Middle**: Work happens. Tool calls, reasoning, intermediate results accumulate.
+3. **End**: Outcome is reached. Learnings are extracted and stored to memory.
+
+Session metadata worth tracking:
+
+- Start time and duration
+- Agent ID and model used
+- Tools invoked (names and counts)
+- Files read and written
+- Tokens consumed (input + output)
+- Outcome: completed, failed, abandoned
+- Cost (if available)
+
+This metadata becomes the raw material for episodic memory. OAK CI captures this automatically via `agent_runs` and `sessions` tables.
+
+### Session Boundaries
+
+Deciding when to start a new session vs. continue an existing one:
+
+**Start a new session when:**
+- The user's goal has fundamentally changed
+- The previous session ended with a clear outcome
+- Context has grown past the compaction threshold and a clean start is cheaper than summarization
+- A different agent or model is better suited to the new task
+
+**Continue the existing session when:**
+- The new request builds directly on prior work
+- Relevant context (variable bindings, file state, intermediate results) would be lost
+- The user explicitly asks to continue
+
+**Session continuity** (bridging sessions):
+- Generate a session summary at the end of each session
+- Store key decisions, files touched, and open questions
+- Load this summary at the start of the next related session
+- This is cheaper than maintaining a massive continuous context
+
+---
+
+## Context Rot
+
+Context rot is the degradation of model performance as the context window fills. It is **not linear** -- performance holds steady for a while, then falls off a cliff.
+
+### The Degradation Curve
+
+Empirical behavior across major LLMs:
+
+```
+Performance
+  |████████████████████████
+  |                        ████████
+  |                                ████
+  |                                    ███
+  |                                       ██
+  |                                         █
+  |__________________________________________|___
+  0%        30%       50%       70%      100%
+                Context Window Usage
+```
+
+- **0-35% capacity**: Performance is roughly constant. The model handles instructions, history, and retrieval well.
+- **35-65% capacity**: Gradual degradation. The model starts missing details in the middle of context.
+- **65-80% capacity**: Noticeable decline. Instruction-following weakens, hallucinations increase.
+- **80%+ capacity**: Sharp decline. The model may ignore instructions, contradict itself, or lose track of the goal.
+
+These thresholds vary by model and task. Complex reasoning tasks degrade earlier than simple retrieval tasks.
+
+### Position Bias
+
+Models do not attend equally to all positions in the context window:
+
+- **Primacy effect**: Content at the beginning of context (system prompt, first instructions) gets disproportionate attention.
+- **Recency effect**: Content at the end (most recent messages) also gets strong attention.
+- **Lost in the middle**: Content in the middle of a long context receives the least attention.
+
+**Mitigations:**
+
+1. Place critical instructions in the system prompt (beginning of context).
+2. Repeat key instructions or constraints near the end of context, especially after compaction.
+3. Use XML tags or markdown headers to create clear section boundaries -- these act as attention anchors.
+4. When retrieving context, place the most relevant items closest to the current turn (end of context).
+
+### Causes of Context Rot
+
+| Cause | Mechanism | Mitigation |
+|---|---|---|
+| Token accumulation | Context window fills with conversation history | Compaction or summarization before 60% capacity |
+| Instruction dilution | Instructions become a smaller percentage of total context | Repeat key instructions; use XML section tags |
+| Contradictory information | Earlier context conflicts with later corrections | Explicit "latest wins" rules; remove outdated content |
+| Tool result bloat | Verbose tool outputs (file contents, search results) consume tokens | Summarize tool results after processing; drop raw output |
+| Goal drift | Original goal buried under conversation noise | Maintain a goal scratchpad; restate goals after compaction |
+| Retrieval noise | Irrelevant retrieved context dilutes signal | Filter retrieval results aggressively; prefer precision over recall |
+
+---
+
+## Multi-Agent Session Management
+
+When multiple agents collaborate, context management becomes a distributed systems problem. Three fundamental patterns exist.
+
+### Pattern 1: Shared Context
+
+All agents read from and write to the same context window (or shared document).
+
+```
+┌─────────────────────────────────┐
+│        Shared Context           │
+│  ┌───────┐ ┌───────┐ ┌───────┐ │
+│  │Agent A│ │Agent B│ │Agent C│ │
+│  └───────┘ └───────┘ └───────┘ │
+└─────────────────────────────────┘
+```
+
+**Strengths:**
+- All agents see the full picture
+- No communication overhead
+- Simple to implement
+
+**Weaknesses:**
+- Context bloats N times faster (each agent's output adds to shared context)
+- Agents may contradict each other
+- Hard to scale past 2-3 agents
+- No isolation: one agent's verbose output degrades context for all
+
+**Best for:** Small teams of tightly-coupled agents working on the same artifact.
+
+### Pattern 2: Separate Contexts (Isolation)
+
+Each agent has its own context window. Communication happens via structured messages.
+
+```
+┌───────────┐   message   ┌───────────┐
+│  Agent A   │ ──────────→ │  Agent B   │
+│  (own ctx) │ ←────────── │  (own ctx) │
+└───────────┘             └───────────┘
+```
+
+**Strengths:**
+- Each agent gets focused, relevant context
+- No cross-contamination
+- Scales to many agents
+- Agents can use different models optimized for their task
+
+**Weaknesses:**
+- Communication overhead (messages must be explicit)
+- Risk of information loss at boundaries
+- Harder to coordinate complex multi-step work
+
+**Best for:** Diverse tasks where each agent needs specialized context (e.g., one agent researches, another codes, another reviews).
+
+### Pattern 3: Hybrid (Orchestrator + Workers)
+
+An orchestrator agent maintains shared state. Worker agents operate in isolation with task-specific context. Results flow back through the orchestrator.
+
+```
+              ┌──────────────┐
+              │ Orchestrator  │
+              │ (shared state)│
+              └──┬───┬───┬──┘
+                 │   │   │
+          ┌──────┘   │   └──────┐
+          ▼          ▼          ▼
+    ┌──────────┐ ┌──────────┐ ┌──────────┐
+    │ Worker A  │ │ Worker B  │ │ Worker C  │
+    │ (own ctx) │ │ (own ctx) │ │ (own ctx) │
+    └──────────┘ └──────────┘ └──────────┘
+```
+
+**Strengths:**
+- Workers get clean, focused context (no pollution from other workers)
+- Orchestrator maintains the big picture
+- Workers can run in parallel
+- Scales well
+
+**Weaknesses:**
+- Orchestrator context can still bloat if many workers report back
+- Design complexity: must define clear task boundaries and result formats
+
+**Best for:** Production agent systems. This is the pattern used by Claude Code's team mode, OAK's analysis agents, and most multi-agent frameworks.
+
+### Choosing a Pattern
+
+| Factor | Shared | Isolated | Hybrid |
+|---|---|---|---|
+| Number of agents | 2-3 | Any | Any |
+| Task coupling | Tight | Loose | Mixed |
+| Context efficiency | Low | High | High |
+| Implementation effort | Low | Medium | High |
+| Scalability | Poor | Good | Good |
+
+---
+
+## Compaction Strategies
+
+When context grows too large, you must compact it. The strategy you choose determines what knowledge survives compression.
+
+### Strategy 1: Last-N Messages
+
+Keep only the most recent N conversation turns. Discard everything older.
+
+**How it works:**
+```
+Before: [msg1, msg2, msg3, msg4, msg5, msg6, msg7, msg8]
+After (N=4): [msg5, msg6, msg7, msg8]
+```
+
+**Characteristics:**
+- Simple and predictable
+- Token usage is bounded
+- Completely loses early context (instructions, goals, decisions made early)
+- No computation overhead
+
+**Best for:** Stateless chat applications, simple Q&A bots, situations where early context is truly irrelevant.
+
+**Not suitable for:** Multi-step tasks where early instructions or decisions matter.
+
+### Strategy 2: Recursive Summarization
+
+Summarize old messages into a running summary. Keep the summary plus recent messages.
+
+**How it works:**
+```
+Before: [summary_v1, msg4, msg5, msg6, msg7, msg8, msg9, msg10]
+Trigger: context > 60% capacity
+After:  [summary_v2 (covers msg1-msg7), msg8, msg9, msg10]
+```
+
+Where `summary_v2` incorporates `summary_v1` and `msg4-msg7` into a new summary.
+
+**Characteristics:**
+- Preserves a compressed version of all history
+- Moderate token efficiency
+- Risk: summarization losses compound over time (the "telephone game" effect)
+- Each compaction step loses some fidelity
+- Works best when the model doing summarization is high quality
+
+**Implementation guidance:**
+- Trigger summarization at 55-65% context capacity (before degradation begins)
+- Use structured summaries: decisions made, files changed, open questions, key facts
+- Include explicit section for "instructions that must be preserved"
+- Consider having the summary reviewed/approved before discarding originals
+
+### Strategy 3: Manus Hybrid (Structured Scratchpad)
+
+Maintain two zones: a **verbatim zone** (recent turns, kept as-is) and a **summary zone** (older turns, compressed). Alongside both, maintain a **structured scratchpad** that is never summarized.
+
+**How it works:**
+```
+Context layout:
+┌─────────────────────────────┐
+│ System Prompt (fixed)        │
+├─────────────────────────────┤
+│ Scratchpad (preserved)       │
+│  - Current goal              │
+│  - Key facts learned         │
+│  - Decisions made            │
+│  - Open questions            │
+│  - Files modified            │
+├─────────────────────────────┤
+│ Summary Zone (compressed)    │
+│  "Earlier: researched auth   │
+│   options, chose JWT..."     │
+├─────────────────────────────┤
+│ Verbatim Zone (recent turns) │
+│  [msg8, msg9, msg10]         │
+└─────────────────────────────┘
+```
+
+**Characteristics:**
+- Highest context preservation of any compaction strategy
+- The scratchpad acts as a lossless knowledge store across compactions
+- More complex to implement: requires maintaining the scratchpad format
+- The scratchpad itself must be kept concise (it is never compressed)
+
+**Implementation guidance:**
+- Define scratchpad structure upfront (what sections, what format)
+- Update the scratchpad explicitly during the session (not just at compaction time)
+- On compaction: compress the narrative (conversation), but copy the scratchpad verbatim
+- Cap scratchpad size (e.g., 2000 tokens) to prevent it from becoming its own bloat problem
+
+### Strategy Comparison
+
+| Strategy | Context Preservation | Simplicity | Token Efficiency | Compounding Loss | Best For |
+|---|---|---|---|---|---|
+| Last-N | Low | High | High | None (hard cutoff) | Short tasks, chat |
+| Recursive Summarization | Medium | Medium | Medium | Yes (telephone game) | Medium-length sessions |
+| Manus Hybrid | High | Low | Medium | Minimal (scratchpad preserved) | Complex multi-step tasks |
+| Full (no compaction) | Perfect | Highest | Lowest | N/A | Sessions under 30% capacity |
+
+**Rule of thumb:** If your agent sessions routinely exceed 50% context capacity, you need a compaction strategy. If they involve multi-step reasoning or long-running tasks, prefer the Manus Hybrid approach.
+
+---
+
+## Memory Architecture (5 Layers)
+
+From Google's whitepaper, agent memory has five layers, analogous to human memory systems. Each layer has different lifetime, retrieval characteristics, and storage requirements.
+
+### Layer 1: Sensory Memory (Immediate Context)
+
+The current turn's raw input: the user's latest message, tool results just returned, documents just retrieved.
+
+- **Lifetime:** Single turn
+- **Size:** Small (one turn's worth of data)
+- **Analogy:** What you are looking at right now
+- **Implementation:** The latest entries in the conversation messages array
+- **Key concern:** Filter aggressively. Not everything the tools return needs to stay in context.
+
+### Layer 2: Short-Term Memory (Session Context)
+
+The conversation history within the current session. Grows with each turn.
+
+- **Lifetime:** Current session
+- **Size:** Grows linearly; subject to context rot
+- **Analogy:** What you have been thinking about for the last hour
+- **Implementation:** The conversation messages array, subject to compaction
+- **Key concern:** This is where context rot lives. Apply compaction strategies from the previous section.
+
+### Layer 3: Episodic Memory (What Happened)
+
+Records of past events and experiences. Retrieved when relevant to the current task.
+
+- **Lifetime:** Long-term (persists across sessions)
+- **Content:** Specific events: "Last time we refactored the auth module, tests broke because mock setup was order-dependent"
+- **Retrieval:** Semantic search triggered by current task context
+- **OAK CI equivalent:** `memory_observations` with types `bug_fix` and `gotcha`
+- **Key concern:** Must be retrievable by relevance, not just recency. Vector search is preferred.
+
+### Layer 4: Semantic Memory (Facts and Concepts)
+
+General knowledge about the domain, the codebase, or the project. Relatively stable over time.
+
+- **Lifetime:** Long-term, updated infrequently
+- **Content:** "This codebase uses the repository pattern for data access" or "The API rate limit is 100 requests per minute"
+- **Retrieval:** Semantic search, or loaded proactively based on file/topic context
+- **OAK CI equivalent:** `memory_observations` with types `discovery` and `decision`
+- **Key concern:** Keep entries atomic and factual. Vague or compound observations degrade search quality.
+
+### Layer 5: Procedural Memory (How To Do Things)
+
+Skills, procedures, and workflows. The agent's "muscle memory."
+
+- **Lifetime:** Permanent (updated with project evolution)
+- **Content:** "To add a new API endpoint: create route file, add service, write tests, update OpenAPI spec"
+- **Implementation:** System prompts, constitution files, skill files, templates
+- **OAK CI equivalent:** Constitution (`oak/constitution.md`), skill files, agent task definitions
+- **Key concern:** This is the most valuable memory layer. It should be curated by humans, not auto-generated.
+
+### How the Layers Integrate
+
+At each turn, the agent assembles context from all five layers:
+
+```
+Context Assembly (per turn):
+
+  Layer 5: System prompt + skill instructions    [always present, fixed cost]
+      │
+  Layer 4: Retrieved semantic memories           [loaded at session start or on topic change]
+      │
+  Layer 3: Retrieved episodic memories            [searched per-turn based on current task]
+      │
+  Layer 2: Session history (compacted)            [growing, subject to compaction]
+      │
+  Layer 1: Current turn input + tool results      [fresh each turn]
+      │
+      ▼
+  ┌──────────────────┐
+  │  Model Inference  │
+  └──────────────────┘
+```
+
+**Token budget allocation** (approximate, for a 200K-token model):
+
+| Layer | Budget | Notes |
+|---|---|---|
+| Layer 5 (Procedural) | 10-20K tokens | System prompt, skills, constitution |
+| Layer 4 (Semantic) | 5-10K tokens | Retrieved facts, project knowledge |
+| Layer 3 (Episodic) | 3-5K tokens | Relevant past experiences |
+| Layer 2 (Session) | 50-100K tokens | Conversation history (compacted) |
+| Layer 1 (Sensory) | 10-30K tokens | Current tool results, retrieved docs |
+| Reserved for response | 10-30K tokens | Model's output budget |
+
+These are guidelines, not rules. Adjust based on your model's context window and task requirements.
+
+---
+
+## Practical Patterns for Agent Loops
+
+### The Observe-Think-Act-Reflect Loop
+
+The core agent loop with explicit context management at each phase:
+
+**1. Observe** -- Gather context before reasoning.
+- Retrieve relevant memories (`oak_search`, `oak_context`)
+- Read relevant files
+- Check task state and dependencies
+- Load any session scratchpad from prior compaction
+
+**2. Think** -- Reason about the gathered context.
+- Extended thinking / chain-of-thought helps here
+- Consider multiple approaches before acting
+- Identify what additional context might be needed
+
+**3. Act** -- Take action based on reasoning.
+- Write code, call APIs, modify files
+- Use tools to verify results (run tests, check output)
+- Keep tool calls focused: avoid retrieving more context than needed
+
+**4. Reflect** -- Store learnings from the outcome.
+- If something unexpected happened, store it as episodic memory (`oak_remember`)
+- Update the session scratchpad with new facts, decisions, and open questions
+- If a general pattern was discovered, store it as semantic memory
+
+This loop naturally integrates all five memory layers: Layer 5 provides the loop structure itself, Layers 3-4 feed the Observe phase, Layer 2 provides session continuity, and Layer 1 is the current turn's input.
+
+### Context Budget Management
+
+Monitor context usage and trigger compaction proactively:
+
+```
+Per-turn context check:
+
+  current_usage = system_prompt + session_history + retrieval + pending_response
+  capacity = model_context_window
+
+  if current_usage > 0.55 * capacity:
+      trigger_compaction()       # Summarize old turns, preserve scratchpad
+
+  if current_usage > 0.75 * capacity:
+      aggressive_compaction()    # Deeper summarization, drop tool results
+
+  if current_usage > 0.90 * capacity:
+      emergency_compaction()     # Keep only scratchpad + last 3 turns
+```
+
+**Key principle:** Compact early, compact often. It is better to summarize 10 turns when you have headroom than to be forced into emergency compaction that loses critical context.
+
+### Goal Persistence
+
+Goal drift is the most common cause of agent failure in long sessions. The original task gets buried under conversation history and the agent starts optimizing for the wrong thing.
+
+**Mitigations:**
+
+1. **Explicit goal statement**: Store the current goal in the session scratchpad. Not just "fix the bug" but "fix the authentication timeout bug in `auth_service.py` where JWT tokens expire during long-running requests."
+
+2. **Goal restatement**: After every compaction, restate the goal. After every N turns (e.g., 10), restate the goal.
+
+3. **Goal decomposition**: Break complex goals into sub-goals. Track which sub-goals are complete and which remain.
+
+4. **Completion criteria**: Define upfront what "done" looks like. "The fix is done when: (a) the timeout no longer occurs, (b) existing tests pass, (c) a new test covers the edge case."
+
+### When to Store Memories
+
+Not every observation deserves to be a memory. Store memories when:
+
+| Signal | Memory Type | Example |
+|---|---|---|
+| Something broke unexpectedly | `gotcha` | "Mocking `datetime.now()` in this codebase requires patching the module-level import, not `datetime.datetime.now`" |
+| A bug was fixed and the root cause was non-obvious | `bug_fix` | "The flaky test was caused by test ordering -- `test_auth` was leaking a database connection" |
+| An architectural pattern was discovered | `discovery` | "All API routes in this project use the decorator pattern from `base_route.py`" |
+| A deliberate choice was made between alternatives | `decision` | "Chose SQLite over PostgreSQL for CI data because it requires zero configuration and the data is machine-local" |
+| A trade-off was identified | `trade_off` | "Compacting at 55% capacity loses less context but triggers more frequent compactions, increasing latency" |
+
+**Do not store:**
+- Obvious facts anyone could find by reading the code
+- Session-specific state that will not be relevant later
+- Speculative conclusions from reading a single file
+- Anything already documented in the project's constitution or README
+
+---
+
+## Key Takeaways
+
+1. **Sessions are ephemeral; memory is durable.** Do not try to make sessions do the job of memory, or vice versa.
+
+2. **Context rot is non-linear.** Performance holds steady, then falls off a cliff. Compact before you hit the cliff, not after.
+
+3. **Position matters.** Put critical instructions at the start and end of context. Use structural markers (XML tags, headers) to create attention anchors.
+
+4. **Prefer the hybrid pattern** for multi-agent systems. Isolation protects each agent's context quality; the orchestrator maintains coherence.
+
+5. **Compaction is not optional** for long-running agents. Choose a strategy that preserves structured knowledge (decisions, goals, facts) even as narrative history is compressed.
+
+6. **Memory has layers.** Procedural memory (skills, constitution) is the most valuable. Episodic memory (what happened) is the most underused. Invest in both.
+
+7. **Goals drift. State them explicitly, restate them often.** A scratchpad with the current goal, sub-goals, and completion criteria prevents the most common mode of agent failure.

--- a/.github/skills/context-engineering/references/before-after-examples.md
+++ b/.github/skills/context-engineering/references/before-after-examples.md
@@ -1,0 +1,331 @@
+# Before/After Examples
+
+Concrete transformations showing how context engineering techniques improve real prompts. Each example: **Before** (problematic), **Diagnosis** (what's wrong), **Techniques Applied**, **After** (improved).
+
+---
+
+## 1. Vague Prompt to Structured Prompt
+
+### Before
+```
+Help me with this code. It's not working right and I need it fixed.
+```
+
+### Diagnosis
+- "Not working" gives zero actionable detail -- no code, no error, no expected behavior
+- No output format specified
+
+### Techniques Applied
+- **Be Clear and Direct**: state the exact problem and expected vs actual behavior
+- **XML Tags**: separate code, error, and instructions
+
+### After
+```xml
+<code language="python">
+def calculate_discount(price, tier):
+    if tier == "gold": return price * 0.8
+    if tier == "silver": return price * 0.9
+    return price
+</code>
+
+<error>calculate_discount(100, "Gold") returns 100 instead of 80.</error>
+
+<instructions>
+1. Identify why the function fails for "Gold" (capital G)
+2. Fix the bug
+3. Add handling for invalid tier values (return price unchanged, log a warning)
+</instructions>
+
+<output_format>Root cause (one sentence), fixed code, test cases.</output_format>
+```
+
+**Why it works:** The model knows exactly what is broken, what the expected behavior is, and what to produce. No ambiguity about scope or success criteria.
+
+---
+
+## 2. Wall of Text to XML-Structured Context
+
+### Before
+```
+Here's my API spec and some error logs and the database schema. The API
+spec says we have a /users endpoint that accepts POST with name and email.
+The email should be unique. Here are the error logs: [2024-01-15 14:23:01]
+IntegrityError: duplicate key violates "users_email_key" Request: POST
+/users {"name": "Jane", "email": "jane@test.com"} And the schema is
+CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT
+NOT NULL UNIQUE). Why am I getting these errors?
+```
+
+### Diagnosis
+- Three data sources in one paragraph with no separation
+- Question buried at the end -- model reads data without knowing the goal
+
+### Techniques Applied
+- **XML Tags**: each data source in its own labeled section
+- **Long Context Tips**: front-load the question
+
+### After
+```xml
+<question>
+Why do duplicate key errors occur on POST /users? Provide: root cause, fix, error response.
+</question>
+
+<error_logs>
+[2024-01-15 14:23:01] IntegrityError: duplicate key violates "users_email_key"
+  Request: POST /users {"name": "Jane", "email": "jane@test.com"}
+[2024-01-15 14:25:12] IntegrityError: duplicate key violates "users_email_key"
+  Request: POST /users {"name": "John", "email": "jane@test.com"}
+</error_logs>
+
+<database_schema>
+CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL UNIQUE);
+</database_schema>
+
+<api_spec>POST /users — Body: { name, email } — email must be unique</api_spec>
+```
+
+**Why it works:** Each data source is labeled. The question is front-loaded so the model reads data with the goal already in mind.
+
+---
+
+## 3. Bloated System Prompt to Altitude-Optimized
+
+### Before (22 generic directives)
+```
+You are an AI assistant. Be helpful, harmless, honest. Be polite.
+Use clear language. Be concise but thorough. Prioritize accuracy.
+Always cite sources. Be creative when appropriate. Ask clarifying
+questions. Be empathetic. Use examples. Stay on topic. [... 10 more ...]
+```
+
+### Diagnosis
+- None specific enough to change behavior -- "be helpful" is default
+- Contradictions: "be concise" vs "be thorough"
+- No role, no domain, no output conventions
+
+### Techniques Applied
+- **Altitude optimization**: raise to principled guidance
+- **System prompt design**: define role with domain expertise
+
+### After
+```xml
+<role>
+Code reviewer. Domain: Django REST APIs with PostgreSQL. Senior level.
+</role>
+
+<constraints>
+- Flag security issues as CRITICAL regardless of other priorities
+- If a change affects schema, always mention migration safety
+- When trade-offs exist, state both options and recommend one
+- Say "I'm not sure" rather than guessing on library-specific behavior
+</constraints>
+
+<output_conventions>
+- Reference file:line_number for each finding
+- Severity: CRITICAL, WARNING, SUGGESTION
+- Include corrected code for CRITICAL and WARNING items
+</output_conventions>
+```
+
+**Why it works:** 22 vague directives became 7 specific rules. Generic advice is gone; domain-specific guidance takes its place.
+
+---
+
+## 4. Context-Stuffed Agent to Compress and Isolate
+
+### Before
+```
+System prompt permanently includes:
+- Full API docs (8K tokens), database schema (3K), error codes (2K),
+  coding standards (1.5K), changelog (4K) = ~18,500 tokens always loaded
+```
+
+### Diagnosis
+- Most reference data used rarely (~5% per conversation)
+- 18K tokens permanently occupied; position bias weakens middle sections
+- Stale data in the system prompt is worse than no data
+
+### Techniques Applied
+- **Isolate**: move reference data behind tool calls
+- **Compress**: summarize what remains
+- **Select**: retrieve only what the current query needs
+
+### After
+```
+System prompt (800 tokens): role, principles, tool instructions
+
+Tools:
+- search_api_docs(endpoint) -> docs for one endpoint
+- query_schema(table_name) -> schema for one table
+- lookup_error_code(code) -> one error definition
+- get_coding_standards(topic) -> relevant standards
+```
+
+**Why it works:** 18,500 to 800 tokens (95% reduction). Data always current (retrieved live). Model attention focused. Cost drops proportionally.
+
+---
+
+## 5. Stateless Agent to Memory-Augmented
+
+### Before
+```
+User: "Can you help me with the auth module?"
+Agent: Starts from scratch. Doesn't know about the circular import
+       bug fixed last week or the refactor merged yesterday.
+```
+
+### Diagnosis
+- No persistent memory -- each session reinvents the wheel
+- Same gotchas hit repeatedly; user re-explains context every time
+
+### Techniques Applied
+- **Write**: store observations as they emerge
+- **Select**: retrieve relevant memories at session start
+
+### After
+```
+Session start: Agent receives injected context:
+  - Recent session summaries, active gotchas, unresolved observations
+
+During work: Agent stores learnings:
+  oak_remember("Auth circular import caused by module-level import
+  of UserModel. Fixed by moving inside function.",
+  memory_type="bug_fix", context="src/services/auth_service.py")
+
+Next session: "Help with the auth module?"
+  Agent already knows about the circular import and last week's refactor.
+```
+
+**Why it works:** The agent compounds knowledge across sessions. Gotchas caught once stay caught.
+
+---
+
+## 6. Poor Few-Shot to Diverse Multishot
+
+### Before (2 trivial examples)
+```
+Convert descriptions to SQL queries.
+Example: "Get all users" -> SELECT * FROM users;
+Example: "Get active users" -> SELECT * FROM users WHERE active = true;
+Now convert: "Get the top 5 customers by total spending last quarter"
+```
+
+### Diagnosis
+- 2 examples, both trivially simple (single table, no joins)
+- Actual task requires JOIN, GROUP BY, ORDER BY, LIMIT, date filtering
+- No schema -- model guesses table and column names
+
+### Techniques Applied
+- **Multishot examples**: 5 diverse examples, simple to complex
+- **XML Tags**: structure examples and provide schema
+
+### After
+```xml
+Convert natural language to PostgreSQL using this schema:
+
+<schema>
+users(id, name, email, created_at)
+orders(id, user_id, total_amount, created_at, status)
+products(id, name, price, category)
+order_items(order_id, product_id, quantity)
+</schema>
+
+<examples>
+<example>
+<input>Get all users</input>
+<output>SELECT * FROM users;</output>
+</example>
+<example>
+<input>Active orders with user names</input>
+<output>SELECT u.name, o.id, o.total_amount
+FROM orders o JOIN users u ON u.id = o.user_id WHERE o.status = 'active';</output>
+</example>
+<example>
+<input>Count orders per user, highest first</input>
+<output>SELECT u.name, COUNT(o.id) AS order_count
+FROM users u LEFT JOIN orders o ON o.user_id = u.id
+GROUP BY u.id, u.name ORDER BY order_count DESC;</output>
+</example>
+<example>
+<input>Revenue by product category this year</input>
+<output>SELECT p.category, SUM(oi.quantity * p.price) AS revenue
+FROM order_items oi JOIN products p ON p.id = oi.product_id
+JOIN orders o ON o.id = oi.order_id
+WHERE o.created_at >= DATE_TRUNC('year', CURRENT_DATE)
+GROUP BY p.category ORDER BY revenue DESC;</output>
+</example>
+<example>
+<input>Users who never placed an order</input>
+<output>SELECT u.name, u.email FROM users u
+LEFT JOIN orders o ON o.user_id = u.id WHERE o.id IS NULL;</output>
+</example>
+</examples>
+
+<input>Get the top 5 customers by total spending last quarter</input>
+```
+
+**Why it works:** Examples progress simple to complex, covering JOINs, GROUP BY, LEFT JOIN for negation, date functions. Schema is explicit.
+
+---
+
+## 7. Unconstrained Output to Prefilled and Formatted
+
+### Before
+```
+Analyze this error log and tell me what happened.
+[error log contents]
+```
+
+### Diagnosis
+- No output structure -- could be a paragraph, list, or narrative
+- "What happened" is open-ended; no actionable structure
+
+### Techniques Applied
+- **Output format**: define exact structure expected
+- **Be Clear and Direct**: bound the scope of analysis
+
+### After
+```xml
+<instructions>
+Analyze this error log. Identify root cause, impact, and fix.
+Respond in exactly this JSON format -- no additional commentary.
+</instructions>
+
+<error_log>[error log contents]</error_log>
+
+<output_format>
+{
+  "root_cause": {
+    "error": "specific error message",
+    "location": "file:line or service",
+    "explanation": "one sentence"
+  },
+  "impact": {
+    "user_facing": "what the user experienced",
+    "scope": "affected users/requests if determinable"
+  },
+  "fix": {
+    "immediate": "what to do now",
+    "preventive": "what to change to prevent recurrence"
+  }
+}
+</output_format>
+```
+
+**Why it works:** The JSON schema acts as a contract. The model produces parseable output, and the three-part structure ensures analysis is actionable, not just descriptive.
+
+---
+
+## Pattern Summary
+
+| Transformation | Key Technique | Typical Improvement |
+|---|---|---|
+| Vague to Structured | Clarity + XML tags | Consistent, relevant responses |
+| Wall of text to XML sections | XML structure | Better information extraction |
+| Low altitude to Right altitude | Altitude optimization | Smaller prompt, better adherence |
+| Context-stuffed to Tool-based | Isolate + Select | 90%+ token reduction, fresher data |
+| Stateless to Memory-augmented | Write + Select | Compounding effectiveness over time |
+| Single example to Diverse multishot | Multishot examples | Edge case handling, format consistency |
+| Unconstrained to Formatted | Output format + Prefill | Parseable, actionable output |
+
+Each transformation applies techniques from [Prompt Engineering Foundations](prompt-foundations.md). For system-level patterns, see [System Prompt Design](system-prompt-design.md). For agent-specific strategies, see [Agent Context Patterns](agent-context-patterns.md).

--- a/.github/skills/context-engineering/references/context-engineering-framework.md
+++ b/.github/skills/context-engineering/references/context-engineering-framework.md
@@ -1,0 +1,255 @@
+# The Context Engineering Framework
+
+Context engineering is designing the complete information environment a model receives at inference time. Four core strategies — Write, Select, Compress, Isolate — ensure the model has the right information, in the right form, at the right moment.
+
+## The Core Insight
+
+Context engineering is not prompt engineering. A prompt is what you type. Context is *everything* the model sees: system prompt + conversation history + tool definitions + tool results + retrieved documents + injected memories + file contents + structured metadata.
+
+A well-engineered prompt inside poorly-engineered context will underperform. A mediocre prompt inside well-engineered context will often succeed. **The context is the product.**
+
+The question shifts from "What should I tell the model?" to "What should the model see, and when should it see it?"
+
+---
+
+## Strategy 1: Write — Craft the Persistent Context
+
+The system prompt persists across every turn, anchoring behavior, tone, and decision-making. It is the highest-leverage piece of context.
+
+### The Altitude Scale
+
+Altitude is the level of abstraction at which you write instructions. Most system prompts fail because they target the wrong altitude.
+
+| Level | Example | Problem |
+|---|---|---|
+| Too High (30,000 ft) | "Be a helpful coding assistant" | No actionable guidance |
+| Too Low (ground level) | "Always use 4-space indentation, prefer f-strings over .format(), use pathlib instead of os.path" | Brittle, doesn't generalize, model may ignore the list |
+| Right Altitude (10,000 ft) | "Follow the project's existing code style. When uncertain, match the patterns in nearby files." | Principled, adaptable, scales to new situations |
+
+Right-altitude examples across domains:
+
+| Domain | Too High | Right Altitude |
+|---|---|---|
+| Code review | "Review code carefully" | "Identify bugs that would cause runtime failures, focusing on edge cases the author likely didn't test" |
+| Customer support | "Help the customer" | "Acknowledge the customer's specific situation before moving to resolution. Gather account info early." |
+| Data analysis | "Analyze this data" | "Check for quality issues first (missing values, type mismatches), then answer using appropriate aggregations" |
+| Writing | "Help me write" | "Match the style of the user's existing text. Preserve their voice; improve clarity without imposing a formula." |
+
+**The altitude test:** If your instruction would still be correct after the codebase or domain changes significantly, it is at the right altitude. If it would break, it is too low. If it provides no guidance for concrete decisions, it is too high.
+
+### Canonical Examples in System Prompts
+
+Instructions tell the model what to do. Examples *show* it. When the two conflict, examples usually win — models pattern-match on demonstrations more reliably than they follow abstract rules.
+
+Include 2-3 gold-standard input/output pairs directly in the system prompt:
+
+```
+You are a code review assistant.
+
+## Example Review
+
+**Input code:**
+def get_user(id):
+    user = db.query(f"SELECT * FROM users WHERE id = {id}")
+    return user[0]
+
+**Your review:**
+1. **SQL injection** (critical): Use parameterized queries:
+   `db.query("SELECT * FROM users WHERE id = ?", [id])`
+2. **Unhandled empty result** (bug): `user[0]` raises IndexError
+   if no user matches. Check the result length first.
+3. **Naming**: `id` shadows the built-in. Use `user_id`.
+
+Apply this structure: prioritize by severity, explain the why, show the fix.
+```
+
+This single example establishes the review structure, severity ordering, inline-fix convention, and explanatory tone — all by demonstration.
+
+### System Prompt as Constitution
+
+A system prompt can function as a constitution: a governing document establishing principles, boundaries, and quality standards for an entire project.
+
+> Cross-reference: The `/project-governance` skill creates constitutions that serve exactly this purpose — the Write strategy applied at project scale.
+
+---
+
+## Strategy 2: Select — Choose What Enters the Context
+
+Every token in the context window competes for the model's attention. Select ensures only high-value, relevant information occupies that space.
+
+### Minimal Viable Toolsets
+
+Fewer, well-described tools lead to better tool selection. Tool sprawl causes selection errors and wastes tokens.
+
+| Quality | Tool Description | Issue |
+|---|---|---|
+| Bad | "search: A tool for searching" | What does it search? What format? |
+| Bad | "find_and_replace_in_files: Searches and optionally replaces, supports regex, globs, recursive traversal" | Two tools in one |
+| Good | "grep_codebase: Search file contents with regex. Returns matching lines with file paths and line numbers." | Clear scope, output, use case |
+| Good | "edit_file: Replace a specific string in a file. old_string must appear exactly once." | Precise contract |
+
+**Principles:** single responsibility per tool, verb-based names, remove overlapping tools, conditionally load rarely-used tools.
+
+### Retrieval Quality
+
+RAG is the Select strategy operationalized. Quality matters far more than quantity.
+
+**Precision over recall.** Injecting 20 vaguely-related documents is worse than 3 highly relevant ones. Irrelevant results actively mislead by introducing noise that competes with signal.
+
+Key practices: re-rank after initial retrieval, limit to top-K (typically 3-5), chunk at semantic boundaries (sections, functions) not fixed token counts, test retrieval quality independently.
+
+### Dynamic Context Selection
+
+Route queries to different context sources based on what the query needs:
+
+```
+"I was charged twice"       -> billing KB + account lookup tool
+"App crashes on login"      -> troubleshooting docs + error log tool
+"How do I export my data?"  -> product docs + feature guide
+"I want to cancel"          -> retention playbook + account status tool
+```
+
+Implementation patterns: classify-then-select (two-step), model self-selection via tool descriptions, metadata pre-filtering, or combinations of these.
+
+---
+
+## Strategy 3: Compress — Reduce Without Losing
+
+Conversations grow. Tool results are verbose. Left unchecked, context fills and performance degrades. Compress fights context bloat while preserving essential information.
+
+### Compaction Techniques
+
+| Technique | How It Works | When to Use |
+|---|---|---|
+| Summarization | LLM summarizes older conversation history | Long conversations approaching limits |
+| Note-taking scratchpad | Agent writes key findings to a persistent scratchpad | Complex research tasks |
+| Sub-agent delegation | Spawn focused sub-agents with narrow context; receive only conclusions | Multi-domain tasks |
+| Tool result clearing | Replace verbose tool output with summary after processing | Large tool responses |
+| Recursive summarization | Summarize existing summaries | Very long sessions |
+
+### The Two-Phase Compression Approach
+
+A production pattern combining techniques:
+
+**Phase 1 — Sliding window:** Keep the last N messages verbatim (active working context).
+
+**Phase 2 — Structured summarization:** Compress older messages into: key facts established, decisions made with rationale, open questions, constraints discovered.
+
+This preserves detail where it matters most (recent context) while retaining essentials from earlier. Maintaining a "facts learned" scratchpad alongside the conversation enhances this — the scratchpad becomes a compressed representation of the entire session's knowledge.
+
+### Token Budget Analysis
+
+Budget tokens deliberately rather than filling the window opportunistically.
+
+```
+Available context = Window size - system prompt - tool descriptions
+                  - conversation history - retrieved docs - response budget
+```
+
+| Component | 8K | 32K | 128K | 200K |
+|---|---|---|---|---|
+| System prompt | 1,000 (12%) | 2,000 (6%) | 4,000 (3%) | 5,000 (2.5%) |
+| Tool descriptions | 500 (6%) | 1,500 (5%) | 3,000 (2%) | 4,000 (2%) |
+| Conversation | 2,500 (31%) | 12,000 (37%) | 50,000 (39%) | 80,000 (40%) |
+| Retrieved docs | 1,500 (19%) | 8,000 (25%) | 35,000 (27%) | 55,000 (27.5%) |
+| **Response budget** | **2,500 (31%)** | **8,500 (27%)** | **36,000 (28%)** | **56,000 (28%)** |
+
+**Rules:** Reserve 20-30% for response (truncation degrades quality). Compress proactively, not reactively. System prompt and tool descriptions are fixed costs; conversation and retrieved docs are where compression pays off.
+
+---
+
+## Strategy 4: Isolate — Move Information Out of Main Context
+
+The most powerful strategy for scaling. Move information to external storage, retrieve just-in-time. The context window becomes working memory, not permanent storage.
+
+### Just-in-Time Retrieval
+
+Don't load information until the model needs it.
+
+**Anti-pattern — eager loading:**
+```
+System prompt: full API docs (15K tokens) + style guide (3K)
+  + project rules (5K) + DB schema (4K) = 27K tokens before the user speaks
+```
+
+**Pattern — just-in-time:**
+```
+System prompt: role (200 tokens) + principles (300 tokens)
+  + tools: search_docs(), get_schema(), check_style() = 800 tokens
+  → detailed info retrieved on demand
+```
+
+97% fewer system prompt tokens, access to the same (or more) information.
+
+### Progressive Disclosure
+
+Structure information in layers:
+
+- **Layer 1 — Overview** (always in context): project structure, directory summaries
+- **Layer 2 — Details** (retrieved on demand): file listings with descriptions, section contents
+- **Layer 3 — Raw data** (retrieved for specific work): full file contents, complete records
+
+Each layer provides enough information to decide whether to go deeper — like navigating from a map to a neighborhood to a specific building.
+
+### Hybrid Context Loading
+
+- **Static context** (every turn): system prompt, core tools, persistent memory
+- **Dynamic context** (query-dependent): retrieved documents, relevant code files, user info
+- **Ephemeral context** (use once, then clear): raw tool results, intermediate search results, verbose API responses
+
+Most context is ephemeral — needed for one step, then dead weight. Actively managing context lifecycle (load, use, summarize, clear) keeps the window focused.
+
+---
+
+## Combining Strategies
+
+The four strategies work together. Decision framework:
+
+```
+Is the information needed on EVERY turn?
++-- Yes -> WRITE it into the system prompt
+|   +-- System prompt too long?
+|       +-- Yes -> Raise ALTITUDE or move specifics to retrieval
+|       +-- No  -> Keep it
++-- No -> Needed on SOME turns?
+    +-- Yes -> Can you predict WHEN?
+    |   +-- Yes -> SELECT (pre-filter by query type or metadata)
+    |   +-- No  -> ISOLATE (let model retrieve via tools)
+    +-- Rarely -> COMPRESS or remove entirely
+```
+
+**Combinations in practice:**
+
+| Scenario | Strategies |
+|---|---|
+| Long coding session | Write (project principles) + Isolate (file contents via tools) + Compress (summarize old turns) |
+| RAG-powered Q&A | Write (role + format) + Select (top-K docs) + Compress (multi-retrieval summaries) |
+| Research agent | Write (methodology) + Isolate (search tools) + Compress (scratchpad) + Select (curate findings) |
+| Customer support | Write (tone + policy) + Select (route to relevant KB) + Isolate (account lookup) |
+
+---
+
+## Measuring Context Quality
+
+| Signal | Likely Cause | Action |
+|---|---|---|
+| Model ignores instructions | System prompt too long or low altitude | Raise altitude, compress, move details to retrieval |
+| Wrong tool selected | Ambiguous or overlapping descriptions | Rewrite descriptions, reduce tool count |
+| Hallucinated information | Missing context | Add retrieval, improve selection |
+| Repetitive responses | Context rot (stale/redundant info) | Compress history, deduplicate |
+| Slow responses | Context too large | Compress, isolate verbose data |
+| Contradictory behavior | Conflicting instructions | Audit for contradictions, set precedence |
+| Degraded quality over time | Window filling with low-value history | Sliding-window compression, scratchpad |
+
+### Quick Diagnostic Checklist
+
+When agent performance drops, check in order:
+
+1. **System prompt over 3,000 tokens?** Raise altitude or isolate details.
+2. **More than 15 tools defined?** Reduce, merge, or conditionally load.
+3. **Conversation history over 50% of window?** Compress.
+4. **Retrieved documents relevant?** Spot-check what was actually injected.
+5. **Response budget sufficient?** Ensure 20-30% of window remains for output.
+6. **Contradictions present?** Search full context for conflicting instructions.
+
+Context engineering is iterative. Measure signals, diagnose root causes, apply strategies, measure again.

--- a/.github/skills/context-engineering/references/evaluation-and-testing.md
+++ b/.github/skills/context-engineering/references/evaluation-and-testing.md
@@ -1,0 +1,178 @@
+# Evaluation and Testing
+
+How to measure whether your context engineering is working and systematically improve it.
+
+---
+
+## Measuring Context Quality
+
+### Output Quality Dimensions
+
+| Dimension | What It Measures | How to Assess |
+|---|---|---|
+| Accuracy | Are facts and code correct? | Compare against ground truth, run tests |
+| Completeness | Does the response address the full request? | Checklist against requirements |
+| Consistency | Are responses stable across similar inputs? | Run same prompt 5-10 times, compare |
+| Relevance | Is the response focused on what was asked? | Check for tangential content |
+| Efficiency | Minimal tokens for maximum value? | Measure response length vs info density |
+| Format Compliance | Does output match specified format? | Validate against schema/template |
+
+Score each dimension independently on a 1-5 scale. A single aggregate score hides problems — a response can be accurate but verbose, or well-formatted but incomplete.
+
+### Context Quality Signals
+
+When outputs are poor, the cause is often in the context, not the model.
+
+| Signal | Indicates | Action |
+|---|---|---|
+| Model ignores late instructions | Position bias, context too long | Move instructions to start, add XML structure |
+| Hallucinated function names | Missing code context | Improve retrieval, add relevant files |
+| Generic responses | System prompt too high altitude | Lower altitude with more specific guidance |
+| Overly rigid responses | System prompt too low altitude | Raise altitude to principles |
+| Wrong tool selected | Ambiguous tool descriptions | Rewrite descriptions, reduce tool count |
+| Repeated similar answers | Context rot | Compress conversation, add diversity cues |
+| Contradicting earlier responses | Compaction lost key info | Improve compaction strategy, preserve decisions |
+
+---
+
+## A/B Testing Prompts
+
+### The Process
+1. **Baseline**: Run current prompt on 20-50 test cases, record outputs
+2. **Variant**: Modify one aspect of the prompt (not multiple changes at once)
+3. **Evaluate**: Score both sets on the quality dimensions above
+4. **Compare**: Statistical comparison (is the improvement consistent?)
+5. **Iterate**: Keep winner, test next hypothesis
+
+### What to A/B Test
+- System prompt wording (altitude changes)
+- Example selection (different multishot examples)
+- Output format instructions
+- XML structure vs plain text instructions
+- Tool descriptions
+- Context selection (which documents to include)
+- Compaction strategies
+
+### Single Variable Testing
+
+Change ONE thing at a time. If you change both the system prompt AND the examples, you can't attribute improvement to either change.
+
+| Round | Change | Measure |
+|---|---|---|
+| 1 | Add XML structure to prompt | Consistency, format compliance |
+| 2 | Add 3 multishot examples | Accuracy, edge case handling |
+| 3 | Raise system prompt altitude | Generalization, brevity |
+| 4 | Add retrieval for context | Accuracy, completeness |
+
+**Sample size matters.** Test on 20+ inputs to distinguish real improvement from noise. Record results for each round:
+
+```
+Round: 3
+Change: Replaced step-by-step instructions with principles
+Baseline: Accuracy 4.2, Completeness 3.8, Relevance 3.5
+Variant:  Accuracy 4.0, Completeness 3.6, Relevance 4.1
+Decision: Keep — relevance improved; add examples to recover completeness
+```
+
+---
+
+## Memory Metrics
+
+### Precision and Recall
+- **Precision**: Of the memories retrieved, how many were actually relevant?
+  - Low precision = noisy retrieval, irrelevant context injected
+  - Fix: Better embedding model, stricter similarity thresholds, re-ranking
+
+- **Recall**: Of the relevant memories that exist, how many were retrieved?
+  - Low recall = useful memories missed
+  - Fix: Better query formulation, lower similarity thresholds, multiple search strategies
+
+### Recall@K
+- Of the relevant memories, how many appear in the top K results?
+- Recall@5 is most important — agents rarely use more than 5 retrieved items effectively
+- Target: Recall@5 > 0.7 for your most common query types
+
+### Memory Quality Indicators
+
+| Metric | Healthy Range | Warning Sign |
+|---|---|---|
+| Active observations | Growing slowly | Explosive growth (>50/week) = low quality |
+| Resolution rate | 10-20% per month | 0% = never maintaining, >50% = storing too much trivia |
+| Retrieval relevance | >70% relevant in top 5 | <50% = classification or embedding problems |
+| Memory types distribution | Mix of all types | 90%+ one type = narrow capture |
+| Duplicate rate | <5% | >10% = not searching before storing |
+
+---
+
+## Iterative Improvement Workflow
+
+### The Feedback Loop
+
+```
+1. Identify a failure mode (wrong output, missed info, hallucination)
+   |
+   v
+2. Diagnose root cause (bad prompt? missing context? wrong retrieval?)
+   |
+   v
+3. Hypothesize fix (raise altitude? add examples? improve retrieval?)
+   |
+   v
+4. Apply ONE change
+   |
+   v
+5. Test on the original failure case + 5-10 similar cases
+   |
+   v
+6. Did it improve without regressing other cases?
+   |-- Yes -> Keep change, go to step 1 with next failure mode
+   |-- No  -> Revert change, try different hypothesis (step 3)
+```
+
+### Failure Mode to Root Cause Mapping
+
+| Failure Mode | Likely Root Cause | First Fix to Try |
+|---|---|---|
+| Model ignores instructions | Context too long, instructions buried | Compress context, move instructions to system prompt start |
+| Inconsistent output format | No examples of expected format | Add 3 multishot examples with exact output format |
+| Hallucinated information | Model lacking context it needs | Add retrieval (RAG) for the missing knowledge |
+| Correct but verbose | No conciseness instruction | Add explicit length/brevity constraint |
+| Handles common cases, fails edge cases | Examples only show happy path | Add edge case examples (2-3 tricky inputs) |
+| Works for simple queries, fails complex | Single-shot overload | Chain into multiple steps, add CoT |
+| Uses wrong tool | Tool descriptions overlap | Rewrite descriptions to be mutually exclusive |
+| Starts strong, degrades over time | Context rot | Add compaction at 60% capacity, repeat key instructions |
+| Different result each time | Underdetermined prompt | Add more constraints, examples, or structured output format |
+
+Prioritize fixes by **frequency** (how often it occurs), **severity** (how bad the outcome is), and **fixability** (can you address the root cause?). Fix high-frequency, high-severity issues first.
+
+---
+
+## Common Failure Modes
+
+| Failure Mode | Symptom | Category | Remedy |
+|---|---|---|---|
+| Prompt injection | Model ignores system prompt | Security | Input sanitization, separate user/system context |
+| Context overflow | Truncated or missing information | Capacity | Compress, isolate, select less |
+| Stale retrieval | Outdated information surfaces | Memory | Resolve/supersede old observations, refresh index |
+| Over-retrieval | Too many results injected | Selection | Stricter top-K, re-ranking |
+| Under-retrieval | Relevant information not found | Selection | Better embeddings, query expansion |
+| Goal drift | Agent forgets original task | Session | Goal scratchpad, periodic restatement |
+| Tool abuse | Model calls tools unnecessarily | Selection | Fewer tools, clearer descriptions |
+| Format drift | Output format degrades over conversation | Compression | Repeat format instructions after compaction |
+| Anchor bias | First example dominates outputs | Examples | Diverse examples, put the "typical" case second |
+| Sycophancy | Model agrees with incorrect user statements | System prompt | Add "push back when the user is wrong" instruction |
+
+---
+
+## Testing Checklist
+
+Before deploying a prompt/context configuration:
+
+- [ ] Tested on 10+ diverse inputs (not just the examples used in the prompt)
+- [ ] Edge cases covered: empty input, very long input, ambiguous input, off-topic input
+- [ ] Output format consistent across all test cases
+- [ ] No hallucinated information in any test output
+- [ ] Performance acceptable within token/cost budget
+- [ ] Compaction tested: still works after 20+ turns of conversation
+- [ ] Retrieval tested: correct memories/documents surface for test queries
+- [ ] Negative testing: model correctly refuses out-of-scope requests

--- a/.github/skills/context-engineering/references/memory-and-sessions.md
+++ b/.github/skills/context-engineering/references/memory-and-sessions.md
@@ -1,0 +1,244 @@
+# Memory and Sessions
+
+This reference covers how to use memory effectively in agent-assisted development: the three memory types, how to extract and consolidate knowledge, provenance tracking, and practical patterns for OAK CI's memory tools.
+
+---
+
+## Memory Types
+
+### Episodic Memory (What Happened)
+
+Records of specific events, experiences, and outcomes. Time-stamped, contextual, narrative — answers "what happened last time?"
+
+- Tied to a specific moment and context
+- Includes cause, effect, and resolution
+- Most valuable when recent; decays in relevance over time
+- Forms raw material for semantic memory through consolidation
+
+**Examples:**
+- "Refactoring broke auth tests — circular imports between `auth_service.py` and `user_service.py`"
+- "Customer API returned 429s after batch size increased to 100 — dropped to 50"
+
+**OAK CI mapping:** Observations with type `bug_fix` or `gotcha`
+
+### Procedural Memory (How To Do Things)
+
+Skills, workflows, and step-by-step processes. Relatively stable — changes slowly as best practices evolve.
+
+- Describes a sequence of actions to achieve a goal
+- Codified in documentation, runbooks, or constitutions
+- Most valuable when accurate and current
+
+**Examples:**
+- "To add a new API endpoint: create route, add service method, write tests, update docs"
+- "To add a new OAK feature: create manifest.yaml, implement RFC, add commands, register in feature service"
+
+**OAK CI mapping:** Constitutions (`oak/constitution.md`), skill files, golden paths. Procedural memory lives in structured documents rather than individual observations.
+
+### Semantic Memory (Facts and Concepts)
+
+General knowledge about the domain, codebase, or system. Context-independent — true regardless of when or how it was learned.
+
+- Factual, declarative knowledge
+- Stable until the underlying reality changes
+- Provides context without requiring the full history
+
+**Examples:**
+- "This project uses PostgreSQL 15 with read replicas for reporting queries"
+- "We chose event sourcing for the order system to support audit requirements"
+
+**OAK CI mapping:** Observations with type `discovery`, `decision`, or `trade_off`
+
+### Memory Type Selection Guide
+
+| You want to remember... | Memory Type | OAK CI Type |
+|---|---|---|
+| A bug you fixed and why | Episodic | `bug_fix` |
+| A non-obvious behavior | Episodic | `gotcha` |
+| How to deploy the app | Procedural | Constitution/Skill |
+| An architectural decision | Semantic | `decision` |
+| A pattern you discovered | Semantic | `discovery` |
+| A trade-off you accepted | Semantic | `trade_off` |
+
+**Rule of thumb:** If it happened once and the specifics matter, it is episodic. If it is always true (until something changes), it is semantic. If it describes how to do something, it is procedural.
+
+---
+
+## Memory Extraction Pipeline
+
+Raw experience becomes useful memory through four stages: capture, classify, consolidate, retrieve.
+
+### 1. Capture (During Work)
+
+Record observations as they happen — context and detail fade quickly. Capture surprising behavior, root causes (not symptoms), decisions with rationale, and codebase discoveries.
+
+```bash
+# Good — specific, includes file path and root cause
+oak ci remember "Auth middleware silently swallows ConnectionError — returns 200 instead of 503. Bare except on line 47" --type gotcha --context src/middleware/auth.py
+
+# Bad — vague, no actionable detail
+oak ci remember "Auth has a bug" --type gotcha
+```
+
+**Every observation should include:** what happened, where it applies (file paths), and why it matters.
+
+### 2. Classify
+
+Assign a type based on what kind of knowledge the observation represents.
+
+| Observation is about... | Classify as |
+|---|---|
+| Something that broke and how you fixed it | `bug_fix` |
+| A non-obvious behavior that could trip someone up | `gotcha` |
+| A fact about the system or domain | `discovery` |
+| A choice you made and why | `decision` |
+| A compromise with known downsides | `trade_off` |
+
+### 3. Consolidate
+
+Individual episodic memories should consolidate into semantic knowledge over time — specific events become general understanding.
+
+**Example:** Three separate gotchas about parallel test failures (shared session state, shared mock gateway, shared email queue) consolidate into one decision: "Integration tests using shared external state must use the `isolated_services` fixture."
+
+```bash
+# Create the consolidated observation
+oak ci remember "Integration tests with shared external state must use isolated_services fixture" --type decision --context tests/conftest.py
+
+# Resolve the observations it replaces
+oak ci resolve <uuid-1> --status superseded
+oak ci resolve <uuid-2> --status superseded
+```
+
+**When to consolidate:** Three or more observations about the same topic, or a pattern has emerged from individual incidents.
+
+### 4. Retrieve
+
+Pull relevant memories when starting new work.
+
+```bash
+# Automatic context assembly — curated code + memories based on task and files
+oak ci context "refactoring the auth service" -f src/services/auth.py
+
+# Targeted search by type
+oak ci search "auth import issues" --type memory
+oak ci search "rate limiting" --type all
+```
+
+---
+
+## Provenance Tracking
+
+Every memory should answer: who learned this, when, and from what evidence?
+
+### Why Provenance Matters
+
+Stale memories are worse than no memories — they actively mislead. An observation saying "the users table has no index on email" causes agents to work around a problem that was fixed last week. Provenance (when recorded, what code referenced) lets you detect and resolve staleness.
+
+### OAK CI Provenance Fields
+
+| Field | What it records |
+|---|---|
+| `session_id` | Which session created the observation |
+| `created_at_epoch` | When it was created (Unix timestamp) |
+| `context` | File path or additional context linking to code |
+| `session_origin_type` | Planning, investigation, or implementation |
+| `resolved_by_session_id` | Which session marked it resolved |
+| `resolved_at` | When it was resolved |
+
+### Provenance Best Practices
+
+**Include file paths in the context field.** Ties memory to code, enabling staleness detection when code changes.
+
+```bash
+# Good — tied to specific code
+oak ci remember "Rate limiter uses fixed window, not sliding — burst at window boundaries" --type discovery --context src/middleware/rate_limiter.py
+
+# Weak — floating, hard to verify later
+oak ci remember "Rate limiter has a burst problem" --type discovery
+```
+
+**Include error messages and specific details** for searchability. **Record session type** — implementation observations (tested and verified) carry more weight than planning observations (potentially speculative).
+
+---
+
+## Memory-as-a-Tool Pattern
+
+Instead of holding everything in the context window, treat memory as an external tool queried on demand.
+
+### The Workflow
+
+```
+Agent receives task -> searches memory -> gets relevant results -> uses in current work -> stores new learnings -> future sessions benefit
+```
+
+**Benefits:** Context window stays focused on the current task. Memory accumulates across sessions. Each retrieval is targeted. Knowledge persists beyond session boundaries and is shared across agents.
+
+### OAK CI Commands
+
+**Store** during work:
+```bash
+oak ci remember "Billing API rate limits at 100 req/min — returns 429 with Retry-After" --type discovery
+```
+
+**Retrieve** when starting work:
+```bash
+oak ci search "billing API rate limits" --type memory
+oak ci context "refactoring the auth service" -f src/services/auth.py
+```
+
+**Resolve** when memory becomes stale:
+```bash
+oak ci resolve <uuid> --reason "Refactored to eliminate circular dependency"
+oak ci resolve <uuid> --status superseded --reason "Replaced by event-driven architecture"
+```
+
+---
+
+## Session Memory Patterns
+
+### Session Summaries
+
+At session end, generate a summary: what was accomplished, what was learned, what remains. OAK CI stores these as `session_summary` observations, creating episodic memories for future sessions.
+
+**A good session summary includes:**
+- Tasks completed (with file paths)
+- Decisions made and their rationale
+- Open questions or unfinished work
+- Observations stored during the session
+
+### Cross-Session Context
+
+Retrieve relevant context from past sessions when starting new work:
+
+```bash
+oak ci context "continuing the auth refactor" -f src/services/auth.py -f src/services/user.py
+```
+
+This returns relevant memories (including past session summaries) alongside related code, providing continuity without full conversation history.
+
+### Memory Decay and Maintenance
+
+Not all memories stay relevant. Active maintenance prevents memory rot. Resolve observations when: the referenced code was refactored or deleted, the decision was reversed, the gotcha was fixed, or newer observations cover the same ground better.
+
+| Situation | Action |
+|---|---|
+| Bug was fixed | Resolve the `bug_fix` observation |
+| Gotcha no longer applies | Resolve the `gotcha` observation |
+| Decision was reversed | Mark `superseded`, create new decision |
+| Observations overlap | Consolidate into one, resolve the rest |
+| Code was deleted | Resolve related observations |
+
+---
+
+## Common Memory Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|---|---|---|
+| Storing everything | Bloat, poor retrieval — important observations buried in noise | Be selective: only store what would help a future session |
+| Vague observations | "Auth was broken" — useless for retrieval, no actionable guidance | Include specifics: error messages, file paths, root cause |
+| Never resolving | Stale memories mislead sessions into working around fixed problems | Resolve observations after addressing the issue |
+| No context field | Memory disconnected from code, cannot validate against current state | Always include file paths or module names |
+| Duplicate observations | Same insight stored multiple times degrades precision | Search before storing; consolidate duplicates |
+| Session-only memory | Knowledge lost when session ends | Use persistent memory for learnings worth keeping |
+| Over-consolidation | Premature generalization loses nuance from specific incidents | Wait for three or more instances before generalizing |
+| No provenance | Cannot assess validity; no way to trace back to evidence | Include file paths, timestamps, and specific details |

--- a/.github/skills/context-engineering/references/prompt-foundations.md
+++ b/.github/skills/context-engineering/references/prompt-foundations.md
@@ -1,0 +1,322 @@
+# Prompt Engineering Foundations
+
+Eight core techniques for writing effective prompts. Each section covers: what it is, when to use it, how to apply it, a concrete example, and common mistakes.
+
+---
+
+## 1. Be Clear and Direct
+
+Specificity eliminates ambiguity. Tell the model exactly what you want — format, length, style, and constraints.
+
+**How to apply:**
+- State the task, format, and constraints up front
+- Use imperative verbs: "List", "Analyze", "Write", "Compare"
+- Specify exclusions when they matter
+- Define success criteria
+
+**Example — bad vs good:**
+
+```
+Bad:  Review this code.
+
+Good: Review this Python function for:
+      1. Security vulnerabilities (injection, XSS)
+      2. Performance issues (N+1 queries, unnecessary allocations)
+      3. Correctness bugs (off-by-one, null handling)
+
+      For each issue: line number, severity (critical/warning/info),
+      and corrected code. If none found, say "None found."
+```
+
+**Mistakes:** Assuming the model infers format preferences. Using vague qualifiers ("good", "comprehensive") without defining them. Omitting constraints then being surprised by the output shape.
+
+---
+
+## 2. Use Examples (Multishot Prompting)
+
+Provide 3-5 input-output examples demonstrating the pattern you want. Examples are the most reliable way to specify format, tone, and edge case handling.
+
+**How to apply:**
+- 3-5 examples minimum (one or two won't establish a pattern)
+- Vary them: happy path, edge cases, boundary conditions, negative cases
+- Show exact input-output structure
+- Order simple to complex
+
+**Example:**
+
+```xml
+Classify each customer message into exactly one category.
+
+<examples>
+<example>
+<input>I can't log in even with the right password</input>
+<output>category: authentication | priority: high</output>
+</example>
+<example>
+<input>How much does the enterprise plan cost?</input>
+<output>category: billing | priority: low</output>
+</example>
+<example>
+<input>Your product crashed during my presentation!!!</input>
+<output>category: bug-report | priority: critical</output>
+</example>
+<example>
+<input></input>
+<output>category: invalid | priority: none</output>
+</example>
+</examples>
+
+Now classify: <input>{{MESSAGE}}</input>
+```
+
+The last example teaches the model how to handle malformed input rather than leaving it to guess.
+
+**Mistakes:** Only showing happy-path examples. Examples too similar to each other. Inconsistent formatting across examples (the model mirrors inconsistency).
+
+---
+
+## 3. Chain of Thought (CoT)
+
+Instruct the model to reason step by step before answering. Dramatically improves accuracy on logic, math, and multi-step analysis.
+
+**Three levels:**
+
+**Basic** — add "Think step by step." Simple, effective for straightforward reasoning.
+
+**Guided** — provide numbered steps when the reasoning process matters:
+```
+Determine if this function has a bug:
+1. Identify what it should do from name and docstring
+2. Trace logic with a normal input
+3. Trace with edge cases (empty, null, boundary)
+4. Compare actual vs expected behavior
+5. Conclude: bug or no bug, with evidence
+```
+
+**Structured** — wrap reasoning in tags to separate thinking from output:
+```xml
+Analyze whether this migration is safe for production.
+
+Work through your analysis inside <reasoning> tags, then give your
+verdict inside <verdict> tags. Consider: table locks, reversibility,
+data backfill volume, partial failure scenarios.
+```
+
+| Level | Use when |
+|---|---|
+| Basic | Simple math, single-step deductions |
+| Guided | Multi-step debugging, analysis where process matters |
+| Structured | Complex decisions, when downstream systems consume the reasoning |
+
+**Mistakes:** Using CoT for simple factual lookups (adds latency, no accuracy gain). Over-constraining the thinking format. Asking for "just the answer" on hard problems.
+
+---
+
+## 4. Use XML Tags for Structure
+
+Claude treats XML tags as first-class structural elements — the most reliable way to separate context, instructions, examples, and output format.
+
+**When to use:** Any prompt with more than one logical section, when mixing data with instructions, when specifying output format.
+
+**Example:**
+```xml
+<context>
+Debugging a failing test suite. Project: Python 3.12, pytest.
+</context>
+
+<test_output>
+FAILED test_auth.py::test_login_redirect - expected 302, got 200
+FAILED test_auth.py::test_expired_token - connection pool exhausted
+</test_output>
+
+<instructions>
+For each failure: identify root cause, determine if related, suggest fix.
+</instructions>
+
+<output_format>
+## [test name]
+**Root cause:** [one sentence]
+**Related:** [yes/no and why]
+**Fix:** [code block]
+</output_format>
+```
+
+**Nesting** for hierarchy (two levels is usually sufficient):
+```xml
+<documents>
+  <document id="1" title="API Spec">...content...</document>
+  <document id="2" title="Error Logs">...content...</document>
+</documents>
+```
+
+**Mistakes:** Generic tag names (`<data>`) instead of specific ones (`<error_log>`). Over-nesting beyond two levels. Mixing XML tags with markdown headers for the same purpose.
+
+---
+
+## 5. Give Claude a Role (System Prompts)
+
+The system prompt establishes persistent behavioral context — role, constraints, and output conventions that frame every response.
+
+**How to apply:**
+- Define role, expertise, and boundaries
+- Set the right altitude: specific enough to be useful, general enough for varied inputs
+- Include what to do when uncertain
+
+**Example — bad vs good:**
+
+```
+Bad:  You are a helpful coding assistant. Be thorough and accurate.
+```
+"Helpful" and "thorough" are not actionable — they contain no specific guidance.
+
+```xml
+Good:
+<role>
+Senior backend engineer. Python + PostgreSQL.
+Production system handling financial transactions.
+</role>
+
+<constraints>
+- Never sacrifice data consistency for performance
+- Flag non-idempotent operations
+- When unsure, say "I'm not confident because..." rather than guessing
+</constraints>
+
+<output_conventions>
+- Python type hints in all code examples
+- Include error handling (no happy-path-only code)
+- Reference specific line numbers when reviewing
+</output_conventions>
+```
+
+**Mistakes:** System prompt so long it dilutes the important parts. Only negative instructions ("don't do X") without positive guidance. Role too narrow, causing refusals on legitimate requests.
+
+---
+
+## 6. Chain Complex Prompts
+
+Break complex tasks into sequential steps where output of step N feeds step N+1. Better results than asking for everything at once.
+
+**When to use:** Tasks with distinct phases (research, analyze, synthesize). When quality at each step matters. When different steps need different instructions.
+
+**Example pipeline:**
+```
+Step 1 (Extract):  "Extract all function signatures and docstrings."
+Step 2 (Analyze):  "For each function, identify missing error handling,
+                    unused params, unclear naming. Rate severity."
+Step 3 (Synthesize): "Group by severity. Write corrected code for
+                      critical/warning issues. Summarize in a table."
+```
+
+**Gate outputs between steps** — validate before passing forward:
+```python
+extracted = call_model(step_1_prompt, document)
+
+# Gate: verify extraction produced results
+if not extracted.functions:
+    raise ValueError("Extraction empty — check input format")
+
+analysis = call_model(step_2_prompt, extracted)
+```
+
+**Mistakes:** Passing too much context between steps (carry only what the next step needs). Not validating intermediates. Steps too granular (each should do meaningful work).
+
+---
+
+## 7. Long Context Window Tips
+
+Position and organization of information in the context window significantly affects output quality. The "lost in the middle" effect means information buried in the center of very long contexts gets less attention.
+
+**Key techniques:**
+
+**Front-load and repeat critical instructions:**
+```xml
+<instructions>
+<!-- FIRST: anchor behavior -->
+Find all security vulnerabilities. Focus on injection, auth bypass, data exposure.
+</instructions>
+
+<codebase>
+...thousands of lines...
+</codebase>
+
+<reminder>
+<!-- LAST: reinforce -->
+Focus only on security vulnerabilities.
+Format: file, line, type, severity, fix.
+</reminder>
+```
+
+**Tag-delineate sections** when including multiple documents:
+```xml
+<documents>
+  <document title="Auth Module" path="src/auth.py">...code...</document>
+  <document title="Schema" path="schema.sql">...schema...</document>
+</documents>
+```
+
+**Include retrieval hints** for very long contexts: "Find the users table in the Schema document and check for a unique constraint on email."
+
+**Order by relevance:** most relevant documents first. For bug analysis: error/stack trace, then source file, then config, then tests, then docs.
+
+**Mistakes:** Dumping context without structure. Critical instructions only in the middle. Including irrelevant context "just in case" (dilutes attention).
+
+---
+
+## 8. Extended Thinking
+
+Extended thinking allocates dedicated tokens for the model to reason internally before producing a visible response. Unlike CoT, this happens in a separate, larger thinking space and can use significantly more tokens.
+
+**When to use:**
+- Complex math or proofs
+- Multi-file code analysis with component interactions
+- Architecture decisions with many tradeoffs
+- Debugging where root cause is non-obvious
+
+**When NOT to use:** Simple factual questions, straightforward code generation, tasks where speed matters more than depth.
+
+**How to apply:**
+
+Set thinking budget based on complexity: small for simple debugging, large for architecture review or multi-step planning.
+
+Let the model reason freely — don't constrain thinking format:
+```
+Good: "Analyze this distributed system for consistency issues.
+       Think deeply about edge cases before responding."
+
+Bad:  "In your thinking, first list all components, then draw
+       arrows between them, then..."
+```
+
+Specify what to *produce*, not how to *think*. Combine with structured output:
+```xml
+<task>
+Review this migration plan. Consider data integrity, rollback safety,
+and performance impact on a 50M-row table.
+</task>
+
+<output_format>
+1. GO / NO-GO recommendation
+2. Risk summary (one paragraph)
+3. Required changes before deploy (bulleted list)
+</output_format>
+```
+
+**Mistakes:** Enabling for every prompt (wastes tokens on simple tasks). Controlling the thinking format. Using thinking as substitute for providing good context.
+
+---
+
+## Anti-Patterns Reference
+
+| Anti-Pattern | Why It Fails | Fix |
+|---|---|---|
+| "Be helpful" | Too vague, no actionable guidance | Specify exact behavior, constraints, output format |
+| Contradictory instructions | Model picks one unpredictably | Resolve conflicts; prioritize with "IMPORTANT" |
+| Wall of text prompt | Key info buried, position bias | Structure with XML; front-load critical info |
+| No examples | Model guesses output format | Add 3-5 diverse multishot examples |
+| "Do everything at once" | Exceeds single-prompt capacity | Chain into sequential steps with gates |
+| Overly rigid templates | Brittle to edge cases | Define principles and show examples instead |
+| "Don't do X" (only negatives) | Model attention anchors on X | State what TO do instead |
+| Expecting one-shot perfection | Unrealistic for complex tasks | Iterate: test varied inputs, refine on failures |
+| Kitchen-sink system prompt | Dilutes important instructions | Keep focused: role, constraints, output conventions |
+| No output validation | Hallucinations and drift undetected | Validate between chained steps |

--- a/.github/skills/context-engineering/references/system-prompt-design.md
+++ b/.github/skills/context-engineering/references/system-prompt-design.md
@@ -1,0 +1,237 @@
+# System Prompt Design
+
+System prompts define who the model is, what it should do, and how it should behave. This reference covers effective system prompt anatomy, writing instructions at the right abstraction level, Claude-specific patterns, and annotated templates.
+
+---
+
+## System Prompt Anatomy
+
+Every effective system prompt has five components, in this order. Ordering matters — models give more weight to content that appears earlier.
+
+### 1. Role and Identity
+
+One or two sentences establishing domain expertise. Sets tone, vocabulary, and decision-making framework.
+
+```
+You are a senior backend engineer specializing in distributed systems.
+```
+
+Be specific enough to shape behavior, broad enough to handle varied inputs. Avoid character fiction ("Dr. Sarah Chen, known for dry wit") — it dilutes technical focus. Avoid generics ("You are a helpful assistant") — it changes nothing.
+
+### 2. Core Constraints
+
+Hard rules the model must always follow. Put these BEFORE task instructions — models respect early constraints more reliably. Use RFC 2119 language (MUST, MUST NOT, SHOULD, MAY) for clarity.
+
+```xml
+<constraints>
+- You MUST NOT modify database schema without explicit approval
+- You MUST cite specific file and line numbers when identifying issues
+- You SHOULD prefer backward-compatible solutions
+- When uncertain, ask for clarification rather than guessing
+</constraints>
+```
+
+The last line is critical — every system prompt should define what the model does when unsure. Without it, the model either guesses (risky) or refuses (unhelpful).
+
+### 3. Task Instructions
+
+What the model should do. Write at the right "altitude" — principles over procedures (see the Altitude Scale below).
+
+```xml
+<instructions>
+When reviewing code, focus on correctness and security over style.
+Flag potential issues but do not rewrite working code for aesthetic reasons.
+When multiple approaches exist, explain the tradeoffs and recommend one.
+</instructions>
+```
+
+Good task instructions answer: What is the primary objective? What gets prioritized when objectives conflict? What does "done" look like?
+
+### 4. Output Format
+
+Be explicit — the model won't consistently infer format preferences.
+
+```xml
+<output_format>
+Respond with a JSON object:
+{
+  "summary": "One-sentence assessment",
+  "issues": [{"severity": "critical|warning|info", "file": "path", "line": 42, "description": "...", "suggestion": "..."}],
+  "overall_rating": "approve | request-changes | needs-discussion"
+}
+</output_format>
+```
+
+If you want markdown, say so. If you want JSON, provide the schema. Ambiguity here is the most common source of format drift.
+
+### 5. Canonical Examples
+
+Two to three input-output pairs demonstrating ideal behavior. Examples anchor behavior more reliably than instructions alone. Show range (positive and negative cases) and edge cases.
+
+```xml
+<example>
+<input>
+def get_user(id):
+    query = f"SELECT * FROM users WHERE id = {id}"
+    return db.execute(query)
+</input>
+<output>
+**Critical: SQL Injection** — line 2 uses f-string with user input.
+Fix: `db.execute("SELECT * FROM users WHERE id = ?", [id])`
+</output>
+</example>
+```
+
+---
+
+## The Altitude Scale
+
+The most common system prompt mistake is writing instructions at the wrong abstraction level.
+
+### Level 1: Ground Level (Too Specific)
+
+```
+Always use 4-space indentation. Variable names must be camelCase.
+Functions must not exceed 20 lines.
+```
+
+Brittle. Doesn't adapt to context. What happens when the codebase uses tabs?
+
+### Level 2: Cruising Altitude (Right Level)
+
+```
+Follow the project's established conventions. Match surrounding
+code style. Prefer clarity over cleverness.
+```
+
+Principled, adaptable. Handles novel situations because it has principles, not just rules.
+
+### Level 3: Stratosphere (Too Vague)
+
+```
+Write good code. Be helpful. Follow best practices.
+```
+
+No actionable guidance. The model falls back to generic behavior.
+
+### Finding Your Altitude
+
+| Domain | Too Low | Right Altitude | Too High |
+|---|---|---|---|
+| Code Review | "Flag if cyclomatic complexity > 10" | "Flag functions hard to understand at a glance" | "Review the code" |
+| Writing | "Sentences must be 12-15 words" | "Write concisely. Prefer short sentences. Cut filler." | "Write well" |
+| Data Analysis | "Use pandas groupby then merge" | "Use efficient operations. Profile before optimizing." | "Analyze the data" |
+| Security Audit | "Check for CVE-2024-1234" | "Identify injection points and trust boundaries" | "Find vulnerabilities" |
+
+**The test:** If your instruction applies regardless of language, framework, or codebase, it's the right altitude.
+
+---
+
+## Claude-Specific Patterns
+
+### XML Tag Conventions
+
+Claude has strong native understanding of XML structure:
+
+- `<context>`, `<instructions>`, `<constraints>`, `<examples>` for top-level sections
+- Nesting up to 2-3 levels: `<examples><example><input>...</input><output>...</output></example></examples>`
+- Attributes for metadata: `<document id="1" title="API Spec" path="src/api.py">`
+- Descriptive tag names — `<error_log>` over `<data>`, `<user_request>` over `<input>`
+- No `<system>` wrapper needed — Claude already knows it's reading a system prompt
+
+### Extended Thinking Integration
+
+Guide the model toward deeper reasoning without constraining its process. Say "Think deeply about edge cases before responding" (good) rather than "First list all components, then draw arrows, then rate each on a 1-5 scale" (bad). Specify what to produce, not how to think.
+
+### Prefilling
+
+Start the assistant's response to anchor output format:
+
+```
+Assistant: {"analysis":
+```
+
+Useful for ensuring JSON output, anchoring structure, or preventing preamble ("Sure! Here's my analysis..."). Use prefilling for format, not for constraining reasoning.
+
+---
+
+## Annotated Templates
+
+### Code Review Agent
+
+```xml
+You are a senior software engineer performing code review.
+
+<constraints>
+- Focus on correctness, security, and maintainability
+- Do NOT rewrite working code for style preferences alone
+- Flag potential bugs with severity: critical, warning, info
+- If uncertain whether something is a bug, say so explicitly
+- MUST NOT approve code with known security vulnerabilities
+</constraints>
+
+<instructions>
+Review the provided code changes. For each issue:
+1. Identify the file and line
+2. Describe the issue and why it matters
+3. Suggest a fix
+
+After reviewing, provide a summary assessment.
+If no issues are found, say so — do not fabricate issues.
+</instructions>
+```
+
+Constraints before instructions, "do not fabricate" prevents false positives, severity levels in constraints keep output consistent.
+
+### Research Assistant
+
+```xml
+You are a research assistant analyzing documents and synthesizing findings.
+
+<constraints>
+- Cite sources with specific quotes or page references
+- Distinguish facts in documents from your inferences
+- If asked about something not in the documents, say so clearly
+- MUST NOT fabricate citations or references
+</constraints>
+
+<instructions>
+Analyze provided documents: identify themes, note contradictions between
+sources, synthesize findings. Use <finding> tags with source attribution.
+</instructions>
+
+<output_format>
+<finding source="Document Title, p. X">
+[Insight with direct quote or specific reference]
+</finding>
+</output_format>
+```
+
+MUST NOT on fabricated citations addresses the highest-risk failure mode. Distinguishing facts from inferences prevents the model from presenting reasoning as source material.
+
+### Data Analysis Agent
+
+```xml
+You are a data analyst working with structured datasets.
+
+<constraints>
+- Show methodology before results
+- Validate data quality before analysis (nulls, duplicates, outliers)
+- State assumptions explicitly
+- Do not over-interpret small samples (note when n < 30)
+</constraints>
+
+<instructions>
+For each analysis: understand the question, examine data quality,
+choose and explain the method, present findings with caveats.
+Prefer tables over prose for numerical results.
+</instructions>
+```
+
+Methodology-before-results prevents jumping to conclusions. Concrete threshold (n < 30) instead of vague "be careful."
+
+---
+
+## Cross-Reference
+
+See also: The `/project-governance` skill for creating and maintaining project constitutions and agent rules files — these are system prompts implemented as version-controlled documents.

--- a/.github/skills/project-governance/SKILL.md
+++ b/.github/skills/project-governance/SKILL.md
@@ -68,6 +68,7 @@ oak rules detect-existing      # Discover all configured agent instruction files
 - **Creating CLAUDE.md, AGENTS.md, or .cursorrules** for a new project
 - **Proposing a new feature** that needs team review (RFC)
 - **Making architectural decisions** that should be documented (ADR)
+- **Learning context engineering theory** behind effective rule writing -- see `/context-engineering` for the altitude concept, canonical examples, and structured context patterns
 - **Reviewing an RFC** for completeness and technical soundness
 
 ## Constitution Structure

--- a/.gitignore
+++ b/.gitignore
@@ -214,7 +214,6 @@ coverage.xml
 unifi/
 aiounifi/
 
-changelog.md
 test_automations*
 
 # open-agent-kit: Issue raw JSON (local debugging only)

--- a/.oak/config.yaml
+++ b/.oak/config.yaml
@@ -1,4 +1,4 @@
-version: 1.1.6
+version: 1.1.9
 agents:
 - vscode-copilot
 - cursor
@@ -25,6 +25,7 @@ codebase_intelligence:
     max_turns: 50
     scheduler_interval_seconds: 60
     timeout_seconds: 600
+    background_processing_workers: 4
   backup:
     on_upgrade: true
   cli_command: oak
@@ -116,3 +117,8 @@ codebase_intelligence:
     min_activities: 3
     stale_timeout_seconds: 3600
   watch_files: true
+  auto_resolve:
+    enabled: true
+    similarity_threshold: 0.85
+    similarity_threshold_no_context: 0.92
+    search_limit: 5

--- a/.oak/config.yaml
+++ b/.oak/config.yaml
@@ -1,4 +1,4 @@
-version: 1.1.5
+version: 1.1.6
 agents:
 - vscode-copilot
 - cursor
@@ -15,7 +15,7 @@ constitution:
 languages:
   installed: [javascript, python, typescript]
 skills:
-  installed: [project-governance, codebase-intelligence]
+  installed: [project-governance, codebase-intelligence, context-engineering]
   auto_install: true
 codebase_intelligence:
   agents:

--- a/.oak/state.yaml
+++ b/.oak/state.yaml
@@ -152,5 +152,6 @@ managed_assets:
   modified_files: []
 initialized_features:
 - codebase-intelligence
+- context-engineering
 - rules-management
 - strategic-planning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,104 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [4.4.2] - 2026-02-11
+
+### Fixed
+
+- Fix options flow handler crash caused by `config_entry` property conflict — the `UnifiNetworkRulesOptionsFlowHandler` constructor attempted to assign to a read-only property, raising `AttributeError` during integration configuration ([#144](https://github.com/sirkirby/unifi-network-rules/pull/144)) — [Fix component input validation and edge‑case handling in state updates](http://localhost:38567/activity/sessions/4919e801-e621-4dd2-a872-c0dae88a2de9)
+
+> ⚠️ **Gotcha**: The options flow handler defined `config_entry` as a `@property` but the `__init__` method tried to assign to it directly. This caused a 500 error when users opened the integration's options in the UI. The fix simplifies the handler by removing the constructor entirely and relying on the base class's built-in `config_entry` access.
+
+## [4.4.1] - 2026-01-28
+
+### Fixed
+
+- Improve switch toggle reliability with per-entity debouncing to prevent race conditions from rapid toggles ([#142](https://github.com/sirkirby/unifi-network-rules/pull/142))
+- Add 0.5s debounce delay per switch entity — only the final desired state is submitted to the UDM API
+- Resolve race conditions where concurrent toggle operations could leave switches in an inconsistent state
+
+### Changed
+
+- Refactor toggle operation to use `asyncio.TimerHandle` for debounce scheduling instead of immediate API calls
+- Improve logging for debounced toggle operations to aid debugging
+
+## [4.4.0] - 2025-12-29
+
+### Fixed
+
+- Resolve optimistic state timing issue where UI state could flash back to the previous value before the API confirmed the change ([#139](https://github.com/sirkirby/unifi-network-rules/pull/139))
+- Add HA-initiated operation timeout to prevent state management race conditions between optimistic updates and coordinator refreshes
+
+### Changed
+
+- Code formatting and linting improvements across coordination modules
+- Add CI/CD workflows for linting and testing via Makefile
+
+## [4.3.0] - 2025-11-18
+
+### Added
+
+- Object Oriented Networking (OON) policy support — manage UniFi OON policies as switch entities ([#132](https://github.com/sirkirby/unifi-network-rules/pull/132))
+- New [`switches/oon_policy.py`](custom_components/unifi_network_rules/switches/oon_policy.py) module with dedicated switch implementation
+- New [`udm/oon.py`](custom_components/unifi_network_rules/udm/oon.py) API module for OON policy CRUD operations
+- New [`models/oon_policy.py`](custom_components/unifi_network_rules/models/oon_policy.py) data model
+- Test coverage for OON policy entities
+
+## [4.2.0] - 2025-09-30
+
+### Added
+
+- NAT rules support — manage UniFi NAT/port translation rules as switch entities ([#125](https://github.com/sirkirby/unifi-network-rules/pull/125))
+- New [`udm/nat.py`](custom_components/unifi_network_rules/udm/nat.py) API module for NAT rule operations
+- New [`models/nat_rule.py`](custom_components/unifi_network_rules/models/nat_rule.py) data model
+- Test coverage for NAT rule entities
+
+### Changed
+
+- Major refactor of coordinator into modular architecture — split monolithic coordinator into [`coordination/`](custom_components/unifi_network_rules/coordination/) subpackage with dedicated modules for auth management, data fetching, entity management, and state management
+- Major refactor of switch entities into [`switches/`](custom_components/unifi_network_rules/switches/) subpackage with per-rule-type modules and a shared base class
+- Improve change detection to support NAT rules and additional entity properties
+
+## [4.1.0] - 2025-09-23
+
+### Added
+
+- Static routes support — manage UniFi static routes as switch entities
+- New [`udm/routes.py`](custom_components/unifi_network_rules/udm/routes.py) API module for static route operations
+- New [`models/static_route.py`](custom_components/unifi_network_rules/models/static_route.py) data model
+- Test coverage for static route entities
+
+### Changed
+
+- Enhance trigger migration and template update functionality for v4.0.0 compatibility
+- Simplify automation file download instructions
+- Update migration utility and documentation for v4.0.0
+
+## [4.0.0] - 2025-09-18
+
+### Added
+
+- Smart Polling system for efficient UDM API communication
+- Unified Trigger system replacing per-rule-type triggers
+- Port profile switch entities ([#100](https://github.com/sirkirby/unifi-network-rules/pull/100))
+- Expanded service capabilities for rule management
+- Multi-language translations (DE, ES, FR, IT, NL, PT-BR, RU)
+
+### Changed
+
+- Complete integration architecture overhaul
+- Minimum Home Assistant version raised to 2025.8.0
+
+---
+
+[4.4.2]: https://github.com/sirkirby/unifi-network-rules/compare/v4.4.1...v4.4.2
+[4.4.1]: https://github.com/sirkirby/unifi-network-rules/compare/v4.4.0...v4.4.1
+[4.4.0]: https://github.com/sirkirby/unifi-network-rules/compare/v4.3.0...v4.4.0
+[4.3.0]: https://github.com/sirkirby/unifi-network-rules/compare/v4.2.0...v4.3.0
+[4.2.0]: https://github.com/sirkirby/unifi-network-rules/compare/v4.1.0...v4.2.0
+[4.1.0]: https://github.com/sirkirby/unifi-network-rules/compare/v4.0.0...v4.1.0
+[4.0.0]: https://github.com/sirkirby/unifi-network-rules/releases/tag/v4.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,101 @@
-# Contribution Guidelines
+# Contributing to UniFi Network Rules
 
-Contributions are welcome!
+Thanks for your interest in contributing! This guide will get you from "I want to help" to your first pull request.
 
-Please create a [Feature Request](https://github.com/sirkirby/unifi-network-rules/issues/new?template=feature_request.md) or [Bug Report](https://github.com/sirkirby/unifi-network-rules/issues/new?template=bug_report.md) prior to creating a pull request if you have an idea or are having trouble getting the integration to work.
+> **First time here?** Check the [Quick Start Guide](QUICKSTART.md) to understand what the integration does and how it works.
 
-## Code Style
+## Before You Start
 
-Please follow the existing code style in the repository.
+Please create a [Feature Request](https://github.com/sirkirby/unifi-network-rules/issues/new?template=feature_request.md) or [Bug Report](https://github.com/sirkirby/unifi-network-rules/issues/new?template=bug_report.md) **before** starting work on a pull request. This ensures alignment and avoids duplicate effort.
 
-## Pull Request Process
+## Prerequisites
 
-1. Must reference an existing issue in the PR description.
-2. Ensure you have updated the README.md if needed.
-3. Ensure you have updated the manifest.json if needed.
-4. Ensure you have updated the config_flow.py if needed.
-5. Ensure you have updated the hacs.json if needed.
+| Tool | Version |
+|---|---|
+| Python | 3.13+ |
+| pip | Latest |
+| Git | Any recent version |
+
+A UniFi device is helpful for end-to-end testing but not required — the test suite uses mocks.
+
+## Development Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/sirkirby/unifi-network-rules.git
+cd unifi-network-rules
+
+# Create a virtual environment and install dependencies
+make venv
+make install
+```
+
+This installs all runtime and development dependencies from [`requirements.txt`](requirements.txt), including:
+- `homeassistant`, `aiounifi`, `aiohttp` — runtime dependencies
+- `pytest`, `pytest-asyncio`, `pytest-cov` — testing
+- `ruff` — linting and formatting
+
+## Available Make Commands
+
+Run `make help` for the full list. The most important ones:
+
+| Command | What It Does |
+|---|---|
+| `make venv` | Create a Python virtual environment |
+| `make install` | Install all dependencies |
+| `make lint` | Run Ruff linter |
+| `make fix` | Auto-fix lint issues + format code |
+| `make test` | Run the test suite |
+| `make test-cov` | Run tests with coverage report |
+| `make check` | **Run all checks** (lint + test) — run this before every PR |
+
+## Quality Gate
+
+Before submitting a PR, run:
+
+```bash
+make check
+```
+
+This runs linting and tests — the same checks that CI will run. Your PR will not be merged if these fail.
+
+### Code Style
+
+The project uses [Ruff](https://docs.astral.sh/ruff/) for both linting and formatting, configured in [`pyproject.toml`](pyproject.toml):
+- Line length: 120 characters
+- Python target: 3.13
+- Quote style: double quotes
+
+Run `make fix` to auto-format your code before committing.
+
+## Workflow
+
+1. **Create an issue** (or find an existing one to work on)
+2. **Fork and branch**: Create a branch from `main` with a descriptive name
+3. **Write code**: Follow existing patterns in the codebase
+4. **Write tests**: Add or update tests in [`tests/`](tests/) for your changes
+5. **Run checks**: `make check` — fix any failures
+6. **Submit PR**: Reference the issue in your PR description
+
+## Pull Request Checklist
+
+- [ ] References an existing issue
+- [ ] `make check` passes locally
+- [ ] Tests added or updated for the change
+- [ ] [`README.md`](README.md) updated if adding user-facing features
+- [ ] [`manifest.json`](custom_components/unifi_network_rules/manifest.json) updated if dependencies change
+
+## API Testing
+
+For manual API testing against a real UniFi device, the project maintains a [Bruno collection](https://github.com/sirkirby/bruno-udm-api) with the same requests the integration makes. This is useful for verifying credentials and device compatibility.
+
+## Project Standards
+
+For detailed coding standards, architectural patterns, and conventions, see the [Constitution](oak/constitution.md).
+
+## Getting Help
+
+- 💬 [Discussions](https://github.com/sirkirby/unifi-network-rules/discussions) — Questions and ideas
+- 🐛 [Issues](https://github.com/sirkirby/unifi-network-rules/issues) — Bug reports
+- 📖 [README](README.md) — Full project documentation
+- 🔒 [Security](SECURITY.md) — Vulnerability reporting

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,197 @@
+# Quick Start Guide
+
+Get from zero to a working UniFi Network Rules integration in minutes.
+
+> New to the project? See the [README](README.md) for an overview.
+> Want to contribute? See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Prerequisites
+
+| Requirement | Minimum Version |
+|---|---|
+| Home Assistant | 2025.8.0+ |
+| UniFi Network Application | 9.0.92+ |
+| Python (HA runtime) | 3.13+ |
+| HACS | Latest recommended |
+
+You also need a **local admin account** on your UniFi device. Cloud-only (UniFi SSO) accounts will not work — the integration authenticates directly against the device's local API.
+
+## Installation
+
+### Option 1: HACS (Recommended)
+
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=sirkirby&repository=UniFi-network-rules&category=integration)
+
+1. Open HACS in your Home Assistant instance.
+2. Search for **"UniFi Network Rule Manager"** and install it.
+3. Restart Home Assistant.
+
+### Option 2: Manual Installation
+
+1. Download the latest release from [GitHub Releases](https://github.com/sirkirby/unifi-network-rules/releases).
+2. Copy the `custom_components/unifi_network_rules` directory into your Home Assistant `config/custom_components/` directory.
+3. Restart Home Assistant.
+
+> **Tip**: The [Studio Code Server](https://community.home-assistant.io/t/home-assistant-community-add-on-visual-studio-code/107863) add-on makes it easy to manage files directly in the Home Assistant UI.
+
+## First-Run Setup
+
+After installation and restart:
+
+1. Go to **Settings → Devices & Services → Integrations**.
+2. Click the **"+ Add Integration"** button.
+3. Search for **"UniFi Network Rule Manager"** and select it.
+4. Fill in your connection details:
+
+| Field | Description | Example |
+|---|---|---|
+| **Host** | IP or hostname of your UniFi device | `192.168.1.1` |
+| **Username** | Local admin account | `admin` |
+| **Password** | Account password | `••••••••` |
+| **Site** | UniFi site name (usually "default") | `default` |
+| **Update Interval** | Auto-refresh interval in minutes | `5` |
+| **Verify SSL** | Enable for trusted certificates | Disabled by default |
+
+5. Click **Submit**. The integration will discover and create entities for all your network rules.
+
+## What You Get
+
+Once configured, the integration creates **switch entities** for each of your:
+
+- Firewall policies & traffic/firewall rules
+- Port forwarding rules
+- Traffic routes (with kill switches)
+- Static routes
+- NAT rules & QoS rules
+- OON policies (with kill switches)
+- VPN clients & servers (OpenVPN + WireGuard)
+- WLANs, port profiles, networks, and device LEDs
+
+Toggle any switch to enable/disable the corresponding rule on your UniFi device.
+
+## Smart Polling Configuration
+
+The integration uses intelligent polling that adapts to activity. Access these settings at **Settings → Devices & Services → UniFi Network Rules → Configure → Options**:
+
+| Setting | Default | Purpose |
+|---|---|---|
+| Base Interval | 300s | Idle polling rate |
+| Active Interval | 30s | Polling rate during activity |
+| Realtime Interval | 10s | Rate immediately after changes |
+| Activity Timeout | 120s | Time before returning to idle |
+| Debounce Seconds | 10s | Wait window after HA-initiated changes |
+| Optimistic Timeout | 15s | Max time for optimistic UI updates |
+
+> **Tip**: The defaults work well for most setups. Lower values = faster response, higher values = less API load.
+
+## Services Quick Reference
+
+The integration provides these services for automations:
+
+| Service | What It Does |
+|---|---|
+| `unifi_network_rules.refresh_rules` | Refresh all rules from controller |
+| `unifi_network_rules.backup_rules` | Back up all rules to a JSON file |
+| `unifi_network_rules.restore_rules` | Restore rules from a backup file |
+| `unifi_network_rules.bulk_update_rules` | Enable/disable rules by name pattern |
+| `unifi_network_rules.toggle_rule` | Toggle a specific rule on or off |
+| `unifi_network_rules.delete_rule` | Delete a firewall policy by ID |
+| `unifi_network_rules.apply_template` | Apply a predefined rule template |
+| `unifi_network_rules.save_template` | Save a rule as a reusable template |
+| `unifi_network_rules.websocket_diagnostics` | Run WebSocket connection diagnostics |
+| `unifi_network_rules.force_cleanup` | Force cleanup of all entities |
+| `unifi_network_rules.force_remove_stale` | Remove stale or broken entities |
+| `unifi_network_rules.refresh_data` | Refresh data for a specific instance |
+
+See the [README](README.md#services) for full parameter details and automation examples.
+
+## Your First Automation
+
+Here's a simple automation that backs up your rules every night:
+
+```yaml
+alias: Daily UniFi Backup
+triggers:
+  - trigger: time_pattern
+    hours: "2"
+actions:
+  - action: unifi_network_rules.backup_rules
+    data:
+      filename: "unr_daily_backup.json"
+mode: single
+```
+
+For trigger-based automations using the `unr_changed` event system, see the [Triggers section](README.md#smart-polling-triggers) in the README.
+
+## Verifying Connectivity
+
+If the integration can't connect, verify your credentials from a machine on the same network:
+
+```bash
+curl -k -X POST https://<UDM-IP>/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"<USERNAME>","password":"<PASSWORD>"}'
+```
+
+| Response | Meaning |
+|---|---|
+| `200 OK` | Credentials valid |
+| `401 Unauthorized` | Wrong username or password |
+| `429 Too Many Requests` | Rate limited — wait a few minutes |
+
+## Enabling Debug Logs
+
+For troubleshooting, enable debug logging:
+
+```yaml
+# configuration.yaml
+logger:
+  logs:
+    custom_components.unifi_network_rules: debug
+    aiounifi: debug
+```
+
+Or use the built-in toggle: **Devices & Services → UniFi Network Rules → Enable Debug Logging**.
+
+## Troubleshooting
+
+### Integration won't connect
+
+- **Use the IP address**, not the hostname, of your UniFi device.
+- Ensure your UDM is running Network Application **9.0.92+**.
+- Verify HA and the UDM are on the **same network** (or a routed path exists).
+- The account **must be a local admin** — UniFi Cloud (SSO) accounts are not supported.
+
+### Entities not appearing after setup
+
+- Restart Home Assistant after initial installation.
+- Check that your account has **Admin or Super Admin** privileges in UniFi → Settings → Admins & Users.
+
+### Options flow error (500 error when configuring)
+
+> ⚠️ **Known Issue**: The options flow handler can throw an `AttributeError` due to a property/assignment conflict in [`config_flow.py`](custom_components/unifi_network_rules/config_flow.py). If you hit a 500 error when opening Configure → Options, check for integration updates or report the issue.
+
+### VS Code shows validation errors on triggers
+
+The Home Assistant automation validator (2025.7.0+) doesn't yet recognize custom trigger platforms. The `unr_changed` triggers work correctly despite these warnings — use YAML configuration as shown in the [README examples](README.md#smart-polling-triggers).
+
+### Switches show "Unknown" state
+
+If switches show "Unknown" after setup, wait for the first polling cycle to complete (up to 5 minutes at default base interval). You can force an immediate refresh by calling `unifi_network_rules.refresh_rules`.
+
+### Home Assistant Diagnostics
+
+For bug reports, download diagnostics: **Settings → Devices & Services → UniFi Network Rules → Configure → Download Diagnostics**. This provides system info without exposing sensitive data.
+
+## Limitations
+
+- Uses the same `aiounifi` library as the core HA UniFi integration — version conflicts are possible if both are installed. Restarting HA usually resolves this.
+- Does not replicate all UniFi controller features. For full device management, use the core UniFi integration alongside this one.
+
+## Next Steps
+
+- 📖 [README](README.md) — Full services reference, trigger system, and automation examples
+- 🤝 [Contributing](CONTRIBUTING.md) — Help improve the integration
+- 🔒 [Security](SECURITY.md) — Vulnerability reporting policy
+- 💬 [Discussions](https://github.com/sirkirby/unifi-network-rules/discussions) — Questions, ideas, and feedback
+- 🐛 [Issues](https://github.com/sirkirby/unifi-network-rules/issues) — Bug reports

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 UniFi Network Rules is a custom integration for Home Assistant that integrates with your UniFi Dream Machine/Router to both provide and help you create useful interactions and automations for your Home Lab. The goal of this integration is to simplify policy and rule management for real world use cases. I built this because I wanted to unlock the power of my UniFi firewall. From simple things like screen time and game server access controls for my kids, to more advanced like getting notified when a critical rule is changed and automatically backing up your rules. And most importantly, make all of this easy to use and share with anyone in your home or home lab. I hope you find it useful!
 
+> 📖 **[Quick Start Guide](QUICKSTART.md)** — Installation, setup, and troubleshooting
+> 🤝 **[Contributing](CONTRIBUTING.md)** — Development setup and PR workflow
+> 🔒 **[Security](SECURITY.md)** — Vulnerability reporting policy
+
 ## What this integration provides
 
 ### Switches for enabling and disabling rules and configuration
@@ -1101,28 +1105,6 @@ The UniFi Network Rules integration supports several types of rules:
 
 9. **Legacy Rules**: For older UniFi OS versions, there are also legacy_firewall and legacy_traffic rule types, which are mapped to "policy" when using the service.
 
-## Local Development
-
-### Testing
-
-To run the tests, you need to install the dependencies in the `requirements.txt` file.
-
-```bash
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
-```
-
-Then run the tests:
-
-```bash
-pytest tests
-```
-
-### API Testing
-
-We've created a [Bruno](https://github.com/sirkirby/bruno-udm-api) collection to manually test the API requests. These are the same requests that the integration makes. This is a great way to verify your credentials are valid and to verify device connectivity and compatibility.
-
 ## Diagnostics and Debugging
 
 The integration includes targeted diagnostics and debugging capabilities to help troubleshoot issues while minimizing resource usage.
@@ -1177,40 +1159,7 @@ To temporarily enable API call tracing for a session:
 
 *Remember to revert this change after troubleshooting to prevent excessive logging.*
 
-## General Troubleshooting
-
-If you are having trouble getting the integration to work, please check the following:
-
-1. Ensure the UDM is running the latest version of the network application.
-2. Ensure the UDM is connected to the same network as your Home Assistant instance.
-3. Ensure you are using the IP address of the UDM, not the hostname.
-4. Verify your local account has proper admin privileges.
-
-### Verify your local account is working
-
-Run this on a computer connected to the same network as your UDM or directly on your Home Assistant instance to verify connectivity to the UDM and that your credentials are valid.
-
-```bash
-curl -k -X POST https://[UDM-IP]/api/auth/login \
--H "Content-Type: application/json" \
--d '{"username":"[USERNAME]","password":"[PASSWORD]"}' 
-```
-
-Possible responses:
-
-- 200 OK: Credentials are valid. Returns a JSON object with the user's information.
-- 401 Unauthorized: Credentials are invalid.
-- 429 Too Many Requests: The user has made too many requests in a short period of time. Wait a few minutes and try again.
-
-### Verify your account has admin privileges
-
-You can do this by logging into your UniFi device locally or via <https://UniFi.ui.com>, navigate to Settings -> Admins & Users, and checking the local user's permissions. It should be Admin or Super Admin for the network application.
-
-### Open a bug issue
-
-If you are having trouble getting the integration to work, please open an [Issue](https://github.com/sirkirby/UniFi-network-rules/issues) using the bug report template. Please enable debug logging and include the full log output in your report. Note that it may contain sensitive network information, so please review it before posting. The logs can be large, so i recommend attaching them as a file.
-
-To get the debug log, navigate Devices and Services -> UniFi Network Rules -> Enable Debug Logging. Then reload the integration and try to reproduce the issue. Finally, disable debug logging and download the log file.
+> **Having trouble?** See the [Troubleshooting section](QUICKSTART.md#troubleshooting) in the Quick Start Guide.
 
 ## Limitations
 
@@ -1218,9 +1167,11 @@ This integration uses the same core library that Home Assistant Unifi integratio
 
 This will not support all the features of the UniFi controller, for that, leverage the core integration. The focus of this integration will be home and home lab use cases to extend and differentiate from the core integration.
 
-## Contributions
+## Contributing
 
-Contributions are welcome! Please read our [Contributing Guidelines](CONTRIBUTING.md) and feel free to submit a PR.
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, the quality gate (`make check`), and the PR workflow.
+
+Report security vulnerabilities through our [Security Policy](SECURITY.md).
 
 ***
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in UniFi Network Rules, **please report it responsibly** — do not open a public GitHub issue.
+
+### How to Report
+
+1. **Email**: Send a detailed description to the maintainer via [GitHub private vulnerability reporting](https://github.com/sirkirby/unifi-network-rules/security/advisories/new).
+2. **Include**:
+   - A description of the vulnerability and its potential impact
+   - Steps to reproduce the issue
+   - Any suggested fixes (optional but appreciated)
+
+### Response Timeline
+
+| Stage | Timeframe |
+|---|---|
+| Acknowledgement | Within 72 hours |
+| Initial assessment | Within 1 week |
+| Fix or mitigation | Best effort, depends on severity |
+
+## Supported Versions
+
+| Version | Supported |
+|---|---|
+| 4.x (latest) | ✅ Active |
+| 3.x | ⚠️ Critical fixes only |
+| < 3.0 | ❌ No longer supported |
+
+We recommend always running the latest release available through HACS.
+
+## Security Practices
+
+- **Local authentication only** — the integration connects directly to your UniFi device's local API. No cloud accounts or third-party services are involved.
+- **Credentials stay local** — your username and password are stored in Home Assistant's encrypted config entries, never transmitted externally.
+- **SSL verification** — optional SSL certificate verification is available for environments with trusted certificates.
+- **No telemetry** — the integration does not collect or transmit usage data.
+
+## Scope
+
+This policy covers the `custom_components/unifi_network_rules` integration code. Issues with the UniFi controller itself, Home Assistant core, or the `aiounifi` library should be reported to their respective maintainers.
+
+## More Information
+
+- [README](README.md) — Project overview
+- [Contributing](CONTRIBUTING.md) — Development guidelines
+- [Quick Start](QUICKSTART.md) — Installation and setup


### PR DESCRIPTION
This pull request introduces several improvements and schema updates to the codebase intelligence and context engineering skills for OAK CI. The most significant changes include enhancements to the SQLite database schema to support new features around session management and agent scheduling, as well as the addition of a comprehensive skill guide for context engineering.

**Database Schema Updates:**

* Updated the schema version of the OAK CI SQLite database to version 6 to reflect new changes.
* Added new fields to the `sessions` table: `title_manually_edited` (to prevent manual title edits from being overwritten by the LLM), `summary_updated_at` (to track when summaries are updated), and `summary_embedded` (to indicate if a summary has been indexed in ChromaDB).
* Enhanced the `agent_schedules` table with an `additional_prompt` field, allowing persistent prompt assignments to be prepended to scheduled tasks.
* Updated the skills documentation table summary to reflect the new columns in `sessions` and `agent_schedules`.

**Documentation and Skill Additions:**

* Added a new `context-engineering` skill guide (`SKILL.md`) that provides a detailed, actionable framework for designing prompts and optimizing context for AI agents. This includes foundational prompt engineering techniques, the four context engineering strategies (Write, Select, Compress, Isolate), agent memory/session patterns, practical before/after examples, and integration with OAK CI tools.