### PR TITLE
fix: unload switch platform on reload (resolves 'already been setup' error)

### DIFF
--- a/custom_components/unifi_network_rules/__init__.py
+++ b/custom_components/unifi_network_rules/__init__.py
@@ -229,12 +229,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    # Only unload platforms that were successfully loaded
     if entry.entry_id in hass.data.get(DOMAIN, {}):
         entry_data = hass.data[DOMAIN][entry.entry_id]
-        loaded_platforms = entry_data.get("loaded_platforms", set())
 
-        LOGGER.debug("Unloading entry: %s with loaded platforms: %s", entry.entry_id, loaded_platforms)
+        LOGGER.debug("Unloading entry: %s with platforms: %s", entry.entry_id, PLATFORMS)
 
         # Unregister coordinator from services
         if "services" in hass.data[DOMAIN] and "unregister_coordinator" in hass.data[DOMAIN]["services"]:
@@ -242,11 +240,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             unregister_coordinator = hass.data[DOMAIN]["services"]["unregister_coordinator"]
             unregister_coordinator(entry.entry_id)
 
-        # Attempt to unload all platforms at once
         try:
-            unload_ok = await hass.config_entries.async_unload_platforms(entry, loaded_platforms)
+            unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
             if not unload_ok:
-                LOGGER.warning("Failed to unload one or more platforms: %s", loaded_platforms)
+                LOGGER.warning("Failed to unload one or more platforms: %s", PLATFORMS)
         except Exception as unload_error:
             LOGGER.exception("Error unloading platforms: %s", unload_error)
             unload_ok = False

--- a/custom_components/unifi_network_rules/manifest.json
+++ b/custom_components/unifi_network_rules/manifest.json
@@ -15,5 +15,5 @@
         "aiounifi>=87.0.0",
         "orjson>=3.8.0"
     ],
-    "version": "4.4.1"
+    "version": "4.4.2"
 }


### PR DESCRIPTION
## Summary

- Fix reload regression where `async_unload_entry` never actually unloaded the switch platform, causing `ValueError: Config entry ... for unifi_network_rules.switch has already been setup!` on any subsequent setup (options save, manual reload, etc.).
- Bump `manifest.json` version to `4.4.2`.

## Root cause

`async_unload_entry` read `entry_data.get("loaded_platforms", set())`, but `"loaded_platforms"` is never written anywhere in the codebase. Every reload therefore called `async_unload_platforms(entry, set())`, which unloads nothing. The switch entity component kept the config entry registered, so the next `async_forward_entry_setups` tripped HA's "already been setup" guard.

Fresh HA restarts masked the bug (in-memory state starts clean). Reloads — which got more reliable after the options-flow cleanup in #144 — surface it consistently.

Fixes #127.

## The fix

Use the module-level `PLATFORMS` constant directly in `async_unload_platforms`, mirroring how `async_setup_entry` already uses it in `async_forward_entry_setups`. Also dropped the stale `loaded_platforms` debug line.

## Test plan

- [x] Reproduced the error locally on a real UDM before the fix
- [x] Applied fix locally; reload no longer errors
- [x] Verified switch toggles work after reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)