### PR TITLE
ci: require PUSH_TOKEN via release environment; auto-create GitHub release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,105 @@
+name: Create GitHub release from tag
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+concurrency:
+  group: create-release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect prerelease
+        id: meta
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "$TAG_NAME" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+          IS_PRERELEASE: ${{ steps.meta.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+
+          AUTO_NOTES=$(gh api "repos/${REPO}/releases/generate-notes" \
+            -f tag_name="$TAG_NAME" \
+            --jq '.body')
+
+          PRERELEASE_BANNER=""
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            PRERELEASE_BANNER=$'> [!WARNING]\n> This is a pre-release. It may contain incomplete features or known issues — pin intentionally.\n\n'
+          fi
+
+          {
+            printf '%s' "$PRERELEASE_BANNER"
+            cat <<'NOTES'
+          ## Install via HACS
+
+          1. Open **HACS** in Home Assistant.
+          2. Search for **UniFi Network Rules** in *Integrations*. If it's not listed, add this repository as a custom repository (category: *Integration*).
+          3. Click **Download** and select this version.
+          4. **Restart Home Assistant**.
+          5. Go to **Settings → Devices & services → Add integration** and search for *UniFi Network Rules*.
+
+          ## Manual install
+
+          1. Download the source archive from this release.
+          2. Copy `custom_components/unifi_network_rules` into your Home Assistant `config/custom_components/` directory.
+          3. Restart Home Assistant and add the integration from **Settings → Devices & services**.
+
+          ---
+
+          NOTES
+            printf '%s\n' "$AUTO_NOTES"
+          } > release-notes.md
+
+          echo "Generated release notes:"
+          echo "------"
+          cat release-notes.md
+          echo "------"
+
+      - name: Create release if missing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+          IS_PRERELEASE: ${{ steps.meta.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Release ${TAG_NAME} already exists; skipping"
+            exit 0
+          fi
+
+          args=(
+            "$TAG_NAME"
+            --title "$TAG_NAME"
+            --notes-file release-notes.md
+            --verify-tag
+          )
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            args+=(--prerelease)
+          fi
+
+          gh release create "${args[@]}"

--- a/.github/workflows/sync-manifest-version.yml
+++ b/.github/workflows/sync-manifest-version.yml
@@ -16,13 +16,23 @@ jobs:
   sync:
     name: Sync manifest.json version to release tag
     runs-on: ubuntu-latest
+    environment: release
     steps:
+      - name: Verify PUSH_TOKEN is configured
+        env:
+          TOKEN_SET: ${{ secrets.PUSH_TOKEN != '' }}
+        run: |
+          if [ "$TOKEN_SET" != "true" ]; then
+            echo "::error::PUSH_TOKEN secret is not set in the 'release' environment. Create a PAT with 'contents:write' from an account that can bypass the main branch ruleset, and add it as PUSH_TOKEN to the 'release' environment."
+            exit 1
+          fi
+
       - name: Checkout main
         uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PUSH_TOKEN }}
 
       - name: Verify tag commit is in main history
         env:


### PR DESCRIPTION
## Summary

Two related workflow changes driven by the failed v4.4.3 sync run ([run 24848919181](https://github.com/sirkirby/unifi-network-rules/actions/runs/24848919181)):

- **Fix the sync push** — `GITHUB_TOKEN` can't bypass the main branch ruleset (PR + required status checks), so the sync commit was created but rejected at push. Switch to a PAT-backed `PUSH_TOKEN` held in a `release` GitHub Environment, mirroring the pattern in `sirkirby/unifi-mcp`.
- **Auto-create GitHub releases** — new `create-release.yml` fires on `v*.*.*` tag pushes, composes a release body with HACS install instructions followed by GitHub's auto-generated changelog, and creates the release.

## What changed

### `sync-manifest-version.yml`
- Job now runs under `environment: release` so environment secrets resolve.
- Added an up-front check that fails fast with a clear error if `PUSH_TOKEN` is missing, instead of silently falling back to `GITHUB_TOKEN` and blowing up at the push step.
- Dropped the `GITHUB_TOKEN` fallback from the checkout `token:` — if the check above passes, we know `PUSH_TOKEN` is set.

### `create-release.yml` (new)
- Trigger: push of a `v*.*.*` tag (same filter as the sync workflow).
- Generates changelog via `gh api /repos/:owner/:repo/releases/generate-notes` (same engine as `--generate-notes`, but composable).
- Prepends a standard HACS install block and a manual-install block.
- Adds a prerelease warning banner when the tag contains `-` (e.g. `v4.4.4-beta.1`), and passes `--prerelease` to `gh release create`.
- No-ops if a release for the tag already exists (safe on re-runs and when releases are cut manually first).
- Uses `GITHUB_TOKEN` only — release creation does not need the ruleset bypass.

## Setup required before this can work

1. Create a Classic or Fine-grained PAT with `contents: write` on this repo from an account that's in the ruleset bypass list (the repo admin role).
2. In **Settings → Environments**, create an environment named `release`.
3. Add `PUSH_TOKEN` as an environment secret with the PAT.
4. (Optional) Add required reviewers to the `release` environment to gate sync/release runs.

## Verified locally

- YAML parses cleanly for both files.
- Ran the release-notes builder against `v4.4.3` using `gh api` and confirmed the rendered markdown contains the HACS block followed by the GitHub auto-generated "What's Changed" section and the full changelog compare link.
- Ran the sync workflow's manifest rewrite against a copy of the real manifest — single-line diff, compact arrays preserved, no trailing newline added.

## Test plan after merge

- [ ] Create the `release` environment and add `PUSH_TOKEN`.
- [ ] Push a test tag (e.g. `v4.4.4-beta.1` on a throwaway branch off main) and confirm:
  - [ ] Manifest sync runs and commits `chore(release): sync manifest.json to v4.4.4-beta.1 [skip ci]` to main
  - [ ] GitHub release is created with the HACS install block and prerelease banner, marked as prerelease
- [ ] Delete the test tag/release; cut the real v4.4.4 tag when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)