### PR TITLE
fix: redact sensitive data from debug logs

### DIFF
--- a/custom_components/unifi_network_rules/__init__.py
+++ b/custom_components/unifi_network_rules/__init__.py
@@ -30,12 +30,15 @@ from .services import async_setup_services
 
 # Import the modular API implementation
 from .udm.api import UDMAPI
+from .utils.logger import install_aiounifi_log_redaction
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up UniFi Network Rules component."""
+    install_aiounifi_log_redaction()
+
     # Initialize domain data if not already done
     hass.data.setdefault(DOMAIN, {})
     # Store shared data
@@ -52,6 +55,8 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up UniFi Network Rules from a config entry."""
+    install_aiounifi_log_redaction()
+
     try:
         # Initialize API
         api = UDMAPI(

--- a/custom_components/unifi_network_rules/config_flow.py
+++ b/custom_components/unifi_network_rules/config_flow.py
@@ -32,6 +32,7 @@ from .const import (
     LOGGER,
 )
 from .udm import UDMAPI, CannotConnect, InvalidAuth
+from .utils.logger import install_aiounifi_log_redaction
 
 # Display the update interval in minutes for better UX
 DEFAULT_UPDATE_INTERVAL_MINUTES = DEFAULT_UPDATE_INTERVAL // 60
@@ -52,6 +53,8 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> None:
     """Validate the user input allows us to connect."""
+    install_aiounifi_log_redaction()
+
     api = UDMAPI(
         data[CONF_HOST],
         data[CONF_USERNAME],

--- a/custom_components/unifi_network_rules/manifest.json
+++ b/custom_components/unifi_network_rules/manifest.json
@@ -15,5 +15,5 @@
         "aiounifi>=87.0.0",
         "orjson>=3.8.0"
     ],
-    "version": "4.4.3"
+    "version": "4.4.4"
 }

--- a/custom_components/unifi_network_rules/udm/api.py
+++ b/custom_components/unifi_network_rules/udm/api.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from ..const import LOGGER
 from ..queue import ApiOperationQueue
+from ..utils.logger import sanitize_auth_data
 from .api_base import UDMAPI as BaseAPI
 from .api_handlers import ApiHandlerMixin
 from .authentication import AuthenticationMixin
@@ -322,19 +323,7 @@ class UDMAPI(
 
     def _sanitize_data_for_logging(self, data: Any) -> Any:
         """Remove sensitive information from data before logging."""
-        if not isinstance(data, dict):
-            return data
-
-        # Create a copy to avoid modifying the original
-        safe_data = data.copy()
-
-        # Remove sensitive fields (passwords, tokens, etc.)
-        sensitive_fields = ["password", "key", "psk", "secret", "token", "auth"]
-        for field in sensitive_fields:
-            if field in safe_data:
-                safe_data[field] = "***REDACTED***"
-
-        return safe_data
+        return sanitize_auth_data(data)
 
     async def refresh_all(self) -> None:
         """Refresh all API data from the controller."""

--- a/custom_components/unifi_network_rules/udm/authentication.py
+++ b/custom_components/unifi_network_rules/udm/authentication.py
@@ -278,7 +278,7 @@ class AuthenticationMixin:
             )
 
             if not has_session:
-                LOGGER.warning("No valid session token, performing full login")
+                LOGGER.debug("No valid session token, performing full login")
                 login_success = await self._try_login()
 
                 # After login, ensure proxy prefix is in base path

--- a/custom_components/unifi_network_rules/udm/firewall.py
+++ b/custom_components/unifi_network_rules/udm/firewall.py
@@ -55,7 +55,7 @@ class FirewallMixin:
 
     async def add_firewall_policy(self, policy_data: dict[str, Any]) -> FirewallPolicy | None:
         """Add a new firewall policy."""
-        LOGGER.debug("Adding firewall policy: %s", policy_data)
+        LOGGER.debug("Adding firewall policy: %s", policy_data.get("name", "unnamed"))
         try:
             # Using is_v2=True because this is a v2 API endpoint
             request = self.create_api_request("POST", API_PATH_FIREWALL_POLICIES, data=policy_data, is_v2=True)
@@ -193,7 +193,7 @@ class FirewallMixin:
 
     async def add_legacy_firewall_rule(self, rule_data: dict[str, Any]) -> FirewallRule | None:
         """Add a new legacy firewall rule."""
-        LOGGER.debug("Adding legacy firewall rule: %s", rule_data)
+        LOGGER.debug("Adding legacy firewall rule: %s", rule_data.get("name", "unnamed"))
         try:
             # Using the correct path constant
             request = self.create_api_request("POST", API_PATH_LEGACY_FIREWALL_RULES, data=rule_data)

--- a/custom_components/unifi_network_rules/udm/network.py
+++ b/custom_components/unifi_network_rules/udm/network.py
@@ -235,16 +235,12 @@ class NetworkMixin:
                             device = Device(device_data)
                             led_capable_devices.append(device)
                             LOGGER.debug(
-                                "Created LED-capable device: %s (%s) - LED state: %s",
-                                device_data.get("name", "Unknown"),
-                                mac,
+                                "Created LED-capable device - LED state: %s",
                                 device_data.get("led_override", "unknown"),
                             )
                         except Exception as device_err:
                             LOGGER.warning(
-                                "Error creating Device object for %s (%s): %s",
-                                device_data.get("name", "unknown"),
-                                mac,
+                                "Error creating Device object: %s",
                                 str(device_err),
                             )
                             continue

--- a/custom_components/unifi_network_rules/udm/port_forward.py
+++ b/custom_components/unifi_network_rules/udm/port_forward.py
@@ -38,7 +38,7 @@ class PortForwardMixin:
 
     async def add_port_forward(self, forward_data: dict[str, Any]) -> PortForward | None:
         """Add a new port forward."""
-        LOGGER.debug("Adding port forward: %s", forward_data)
+        LOGGER.debug("Adding port forward: %s", forward_data.get("name", "unnamed"))
         try:
             # Using the path constant from const.py
             request = self.create_api_request("POST", API_PATH_PORT_FORWARDS, data=forward_data)

--- a/custom_components/unifi_network_rules/udm/qos.py
+++ b/custom_components/unifi_network_rules/udm/qos.py
@@ -73,7 +73,7 @@ class QoSMixin:
         Returns:
             QoSRule object if successful, None otherwise
         """
-        LOGGER.debug("Adding QoS rule: %s", rule_data)
+        LOGGER.debug("Adding QoS rule: %s", rule_data.get("name", "unnamed"))
         try:
             # Using is_v2=True because this is a v2 API endpoint
             request = self.create_api_request("POST", API_PATH_QOS_RULES, data=rule_data, is_v2=True)

--- a/custom_components/unifi_network_rules/udm/routes.py
+++ b/custom_components/unifi_network_rules/udm/routes.py
@@ -42,7 +42,7 @@ class RoutesMixin:
 
     async def add_traffic_route(self, route_data: dict[str, Any]) -> TrafficRoute | None:
         """Add a new traffic route."""
-        LOGGER.debug("Adding traffic route: %s", route_data)
+        LOGGER.debug("Adding traffic route: %s", route_data.get("name", "unnamed"))
         try:
             # Using is_v2=True because this is a v2 API endpoint
             request = self.create_api_request("POST", API_PATH_TRAFFIC_ROUTES, data=route_data, is_v2=True)

--- a/custom_components/unifi_network_rules/udm/traffic.py
+++ b/custom_components/unifi_network_rules/udm/traffic.py
@@ -38,7 +38,7 @@ class TrafficMixin:
 
     async def add_traffic_rule(self, rule_data: dict[str, Any]) -> TrafficRule | None:
         """Add a new traffic rule."""
-        LOGGER.debug("Adding traffic rule: %s", rule_data)
+        LOGGER.debug("Adding traffic rule: %s", rule_data.get("name", "unnamed"))
         try:
             # Using is_v2=True because this is a v2 API endpoint
             request = self.create_api_request("POST", API_PATH_LEGACY_TRAFFIC_RULES, data=rule_data, is_v2=True)

--- a/custom_components/unifi_network_rules/utils/logger.py
+++ b/custom_components/unifi_network_rules/utils/logger.py
@@ -4,14 +4,97 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import json
 import logging
+import re
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any, TypeVar
+from urllib.parse import urlsplit, urlunsplit
+
+from homeassistant.helpers.redact import async_redact_data
 
 from ..const import LOG_API_CALLS, LOG_DATA_UPDATES, LOG_ENTITY_CHANGES, LOG_WEBSOCKET, LOGGER
 
 F = TypeVar("F", bound=Callable[..., Any])
+REDACTED = "***REDACTED***"
+
+SENSITIVE_LOG_KEYS = frozenset(
+    {
+        "adopt_ip",
+        "apiKey",
+        "api_key",
+        "auth",
+        "authorization",
+        "connect_request_ip",
+        "cookie",
+        "cookies",
+        "credentials",
+        "deviceToken",
+        "email",
+        "gateway",
+        "host",
+        "hostname",
+        "inform_ip",
+        "ip",
+        "ipv6",
+        "key",
+        "mac",
+        "maskedEmail",
+        "nfc_display_id",
+        "nfc_token",
+        "openvpn_password",
+        "openvpn_username",
+        "passphrase",
+        "password",
+        "phone",
+        "private_key",
+        "psk",
+        "secret",
+        "serial",
+        "service_mac",
+        "session",
+        "set-cookie",
+        "sso_account",
+        "sso_username",
+        "sso_uuid",
+        "token",
+        "uid_sso_account",
+        "user",
+        "user_email",
+        "user_id",
+        "username",
+        "wireguard_private_key",
+        "x-auth-token",
+        "x-csrf-token",
+        "x-updated-csrf-token",
+        "x_authkey",
+        "x_auth_token",
+    }
+)
+
+_SENSITIVE_LOG_KEYS_NORMALIZED = {key.replace("-", "_").casefold() for key in SENSITIVE_LOG_KEYS}
+_SENSITIVE_KEY_PARTS = (
+    "api_key",
+    "authkey",
+    "cookie",
+    "credential",
+    "password",
+    "private_key",
+    "secret",
+    "token",
+)
+_IP_KEY_SUFFIXES = ("_ip", "_ipv6")
+_MAC_KEY_SUFFIXES = ("_mac", "_macs", "mac_address", "mac_addresses")
+_EMAIL_PATTERN = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+_IPV4_PATTERN = re.compile(
+    r"\b(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)\b"
+)
+_MAC_PATTERN = re.compile(r"\b[0-9A-F]{2}(?::[0-9A-F]{2}){5}\b", re.IGNORECASE)
+_UNR_ENTITY_ID_PATTERN = re.compile(r"\b(?:switch\.)?unr_[a-z0-9_]+\b", re.IGNORECASE)
+_URL_AUTHORITY_PATTERN = re.compile(r"\b(?P<scheme>https?|wss?)://[^/\s)\]>'\"]+")
+_LOG_REDACTION_FILTER: RedactingLogFilter | None = None
+_REDACTED_LOGGER_PREFIXES = ("aiounifi", "custom_components.unifi_network_rules")
 
 
 def _is_debug_enabled() -> bool:
@@ -87,20 +170,160 @@ def async_log_execution_time(func: Callable) -> Callable:
     return wrapper
 
 
-# Provide a sanitizer function to clean sensitive data from logs
-def sanitize_auth_data(data: dict) -> dict:
-    """Remove sensitive authentication data for logging."""
-    if not data or not isinstance(data, dict):
+def _redacted(_: Any) -> str:
+    """Return the integration's redaction marker."""
+    return REDACTED
+
+
+def _is_sensitive_log_key(key: Any) -> bool:
+    """Return whether a mapping key should be redacted in logs."""
+    normalized = str(key).replace("-", "_").casefold()
+    return (
+        normalized in _SENSITIVE_LOG_KEYS_NORMALIZED
+        or any(part in normalized for part in _SENSITIVE_KEY_PARTS)
+        or normalized.endswith(_IP_KEY_SUFFIXES)
+        or normalized.endswith(_MAC_KEY_SUFFIXES)
+    )
+
+
+def _collect_sensitive_keys(data: Any) -> set[Any]:
+    """Collect exact sensitive keys so Home Assistant's redactor can redact them."""
+    keys: set[Any] = set()
+
+    if isinstance(data, Mapping):
+        for key, value in data.items():
+            if _is_sensitive_log_key(key):
+                keys.add(key)
+            else:
+                keys.update(_collect_sensitive_keys(value))
+    elif isinstance(data, list):
+        for item in data:
+            keys.update(_collect_sensitive_keys(item))
+
+    return keys
+
+
+def sanitize_auth_data(data: Any) -> Any:
+    """Remove sensitive authentication and identity data before logging."""
+    if not data:
         return data
 
-    sanitized = data.copy()
-    sensitive_keys = ["password", "token", "apiKey", "api_key", "secret", "auth", "credentials", "cookie"]
+    to_redact = dict.fromkeys(_collect_sensitive_keys(data), _redacted)
+    return _sanitize_log_data(async_redact_data(data, to_redact))
 
-    for key in sensitive_keys:
-        if key in sanitized:
-            sanitized[key] = "***REDACTED***"
 
-    return sanitized
+def _safe_log_url(value: str) -> str:
+    """Redact URL authority while preserving scheme and path for debugging."""
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return value
+
+    if parsed.scheme not in {"http", "https", "ws", "wss"} or not parsed.netloc:
+        return value
+
+    return urlunsplit((parsed.scheme, REDACTED, parsed.path, parsed.query, ""))
+
+
+def _sanitize_log_text(value: str) -> str:
+    """Redact common PII shapes from unstructured log text."""
+    value = _URL_AUTHORITY_PATTERN.sub(r"\g<scheme>://" + REDACTED, value)
+    value = _UNR_ENTITY_ID_PATTERN.sub(REDACTED, value)
+    value = _EMAIL_PATTERN.sub(REDACTED, value)
+    value = _IPV4_PATTERN.sub(REDACTED, value)
+    return _MAC_PATTERN.sub(REDACTED, value)
+
+
+def _sanitize_log_data(value: Any) -> Any:
+    """Recursively sanitize non-keyed string values in structured log data."""
+    if isinstance(value, Mapping):
+        return {key: _sanitize_log_data(item) for key, item in value.items()}
+
+    if isinstance(value, list):
+        return [_sanitize_log_data(item) for item in value]
+
+    if isinstance(value, str):
+        return _sanitize_log_text(_safe_log_url(value))
+
+    return value
+
+
+def _sanitize_json_log_text(value: str) -> str | None:
+    """Sanitize a string containing a JSON object or array."""
+    stripped = value.strip()
+    if not stripped or stripped[0] not in {"{", "["}:
+        return None
+
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+
+    return json.dumps(sanitize_auth_data(parsed), separators=(",", ":"), sort_keys=True)
+
+
+def sanitize_log_value(value: Any) -> Any:
+    """Return a logging value with sensitive payloads redacted."""
+    if isinstance(value, bytes | bytearray):
+        return f"<{len(value)} bytes>"
+
+    if isinstance(value, str):
+        return _sanitize_json_log_text(value) or _sanitize_log_text(_safe_log_url(value))
+
+    if isinstance(value, Mapping | list):
+        return sanitize_auth_data(value)
+
+    if value.__class__.__name__ == "ClientResponse":
+        status = getattr(value, "status", "unknown")
+        reason = getattr(value, "reason", "")
+        return f"<ClientResponse [{status} {reason}]>"
+
+    if not isinstance(value, bool | int | float | type(None)):
+        return _sanitize_log_text(str(value))
+
+    return value
+
+
+class RedactingLogFilter(logging.Filter):
+    """Logging filter that redacts structured values before formatting."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Redact sensitive log record arguments."""
+        if not record.name.startswith(_REDACTED_LOGGER_PREFIXES):
+            return True
+
+        record.msg = sanitize_log_value(record.msg)
+
+        if isinstance(record.args, Mapping):
+            record.args = sanitize_auth_data(record.args)
+        elif isinstance(record.args, tuple):
+            record.args = tuple(sanitize_log_value(arg) for arg in record.args)
+        elif record.args:
+            record.args = sanitize_log_value(record.args)
+
+        return True
+
+
+def _add_filter_if_missing(target: logging.Handler | logging.Logger) -> None:
+    """Add the shared redaction filter to a logger or handler."""
+    if _LOG_REDACTION_FILTER is not None and not any(
+        existing is _LOG_REDACTION_FILTER for existing in target.filters
+    ):
+        target.addFilter(_LOG_REDACTION_FILTER)
+
+
+def install_aiounifi_log_redaction() -> None:
+    """Install redaction filters for integration and aiounifi logs."""
+    global _LOG_REDACTION_FILTER
+
+    if _LOG_REDACTION_FILTER is None:
+        _LOG_REDACTION_FILTER = RedactingLogFilter()
+
+    for logger_name in (*_REDACTED_LOGGER_PREFIXES, "aiounifi.interfaces.connectivity"):
+        _add_filter_if_missing(logging.getLogger(logger_name))
+
+    for handler in logging.getLogger().handlers:
+        _add_filter_if_missing(handler)
 
 
 def log_call(func: F) -> F:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -164,6 +164,11 @@ async def test_sanitize_data_for_logging():
         "psk": "pre_shared_key",
         "secret": "top_secret",
         "auth": "auth_token",
+        "nested": {
+            "openvpn_password": "vpn_password",
+            "wireguard_private_key": "private_key",
+            "client": [{"mac": "aa:bb:cc:dd:ee:ff", "ip": "192.168.1.10"}],
+        },
         "safe_field": "visible_data",
     }
 
@@ -176,13 +181,18 @@ async def test_sanitize_data_for_logging():
     assert sanitized["psk"] == "***REDACTED***"
     assert sanitized["secret"] == "***REDACTED***"
     assert sanitized["auth"] == "***REDACTED***"
+    assert sanitized["username"] == "***REDACTED***"
+    assert sanitized["nested"]["openvpn_password"] == "***REDACTED***"
+    assert sanitized["nested"]["wireguard_private_key"] == "***REDACTED***"
+    assert sanitized["nested"]["client"][0]["mac"] == "***REDACTED***"
+    assert sanitized["nested"]["client"][0]["ip"] == "***REDACTED***"
 
     # Safe fields should be unchanged
-    assert sanitized["username"] == "admin"
     assert sanitized["safe_field"] == "visible_data"
 
     # Original data should be unchanged
     assert data["password"] == "secret_password"
+    assert data["nested"]["client"][0]["ip"] == "192.168.1.10"
 
     # Test with non-dict data
     assert api._sanitize_data_for_logging("string_data") == "string_data"

--- a/tests/test_logging_redaction.py
+++ b/tests/test_logging_redaction.py
@@ -1,0 +1,162 @@
+"""Tests for log redaction helpers."""
+
+import logging
+
+from custom_components.unifi_network_rules.utils.logger import (
+    RedactingLogFilter,
+    sanitize_auth_data,
+    sanitize_log_value,
+)
+
+
+def test_sanitize_auth_data_redacts_nested_sensitive_values():
+    """Test nested authentication and identity fields are redacted."""
+    payload = {
+        "Username": "admin",
+        "password": "secret",
+        "headers": {
+            "Set-Cookie": "TOKEN=abc",
+            "X-Csrf-Token": "csrf-token",
+        },
+        "devices": [
+            {
+                "mac": "aa:bb:cc:dd:ee:ff",
+                "ip": "192.168.1.10",
+                "name": "switch-office",
+            }
+        ],
+    }
+
+    redacted = sanitize_auth_data(payload)
+
+    assert redacted["Username"] == "***REDACTED***"
+    assert redacted["password"] == "***REDACTED***"
+    assert redacted["headers"]["Set-Cookie"] == "***REDACTED***"
+    assert redacted["headers"]["X-Csrf-Token"] == "***REDACTED***"
+    assert redacted["devices"][0]["mac"] == "***REDACTED***"
+    assert redacted["devices"][0]["ip"] == "***REDACTED***"
+    assert redacted["devices"][0]["name"] == "switch-office"
+
+    assert payload["password"] == "secret"
+    assert payload["devices"][0]["ip"] == "192.168.1.10"
+
+
+def test_sanitize_log_value_redacts_controller_url():
+    """Test URLs logged by dependencies do not expose controller addresses."""
+    assert sanitize_log_value("https://192.168.1.1:443/api/auth/login") == "https://***REDACTED***/api/auth/login"
+
+
+def test_sanitize_log_value_redacts_unifi_entity_ids():
+    """Test entity IDs derived from user rule names are redacted."""
+    assert sanitize_log_value("switch.unr_traffic_route_personal_laptop_to_fiber") == "***REDACTED***"
+
+
+def test_sanitize_log_value_redacts_json_websocket_payload():
+    """Test JSON websocket payloads are sanitized when logged as strings."""
+    payload = (
+        '{"meta":{"message":"sta:sync","mac":"aa:bb:cc:dd:ee:ff"},'
+        '"data":[{"hostname":"laptop","last_ip":"192.168.1.20",'
+        '"user":"11:22:33:44:55:66","url":"https://192.168.1.1/fingerprint",'
+        '"msg":"User[11:22:33:44:55:66] connected"}]}'
+    )
+
+    redacted = sanitize_log_value(payload)
+
+    assert "aa:bb:cc:dd:ee:ff" not in redacted
+    assert "11:22:33:44:55:66" not in redacted
+    assert "192.168.1.20" not in redacted
+    assert "192.168.1.1" not in redacted
+    assert "laptop" not in redacted
+    assert "***REDACTED***" in redacted
+    assert "sta:sync" in redacted
+
+
+def test_redacting_log_filter_sanitizes_aiounifi_debug_record():
+    """Test aiounifi-style debug records are redacted before formatting."""
+    record = logging.LogRecord(
+        name="aiounifi.interfaces.connectivity",
+        level=logging.DEBUG,
+        pathname=__file__,
+        lineno=1,
+        msg="sending (to %s) %s, %s, %s",
+        args=(
+            "https://192.168.1.1:443/api/auth/login",
+            "post",
+            {"username": "admin", "password": "secret", "rememberMe": True},
+            True,
+        ),
+        exc_info=None,
+    )
+
+    RedactingLogFilter().filter(record)
+    message = record.getMessage()
+
+    assert "192.168.1.1" not in message
+    assert "admin" not in message
+    assert "secret" not in message
+    assert "***REDACTED***" in message
+    assert "rememberMe" in message
+
+
+def test_redacting_log_filter_sanitizes_integration_child_logger_record():
+    """Test integration child logger records are redacted before formatting."""
+    record = logging.LogRecord(
+        name="custom_components.unifi_network_rules.switches.base",
+        level=logging.DEBUG,
+        pathname=__file__,
+        lineno=1,
+        msg="Entity %s updated from %s",
+        args=("switch.unr_traffic_route_personal_laptop_to_fiber", "aa:bb:cc:dd:ee:ff"),
+        exc_info=None,
+    )
+
+    RedactingLogFilter().filter(record)
+    message = record.getMessage()
+
+    assert "personal_laptop" not in message
+    assert "aa:bb:cc:dd:ee:ff" not in message
+    assert message == "Entity ***REDACTED*** updated from ***REDACTED***"
+
+
+def test_redacting_log_filter_sanitizes_stringified_response_objects():
+    """Test response-like objects cannot leak URLs through stringification."""
+
+    class ResponseLike:
+        def __str__(self) -> str:
+            return "<ClientResponse(https://192.168.1.1/api) [200 None]>"
+
+    record = logging.LogRecord(
+        name="aiounifi.interfaces.connectivity",
+        level=logging.DEBUG,
+        pathname=__file__,
+        lineno=1,
+        msg="received %s",
+        args=(ResponseLike(),),
+        exc_info=None,
+    )
+
+    RedactingLogFilter().filter(record)
+    message = record.getMessage()
+
+    assert "192.168.1.1" not in message
+    assert "https://***REDACTED***/api" in message
+
+
+def test_redacting_log_filter_summarizes_bytes():
+    """Test raw response bodies are summarized rather than logged."""
+    record = logging.LogRecord(
+        name="aiounifi.interfaces.connectivity",
+        level=logging.DEBUG,
+        pathname=__file__,
+        lineno=1,
+        msg="data (from %s) %s",
+        args=("https://192.168.1.1:443/api/auth/login", b'{"username":"admin"}'),
+        exc_info=None,
+    )
+
+    RedactingLogFilter().filter(record)
+    message = record.getMessage()
+
+    assert "192.168.1.1" not in message
+    assert "admin" not in message
+    assert "<20 bytes>" in message


### PR DESCRIPTION
## Summary

Fixes noisy and overly verbose logging around UniFi authentication and debug output. The self-healing full-login path now logs at debug level, and dependency/integration debug logs are redacted before formatting so sensitive controller, auth, and client identity data is not written to Home Assistant logs.

This PR uses Home Assistant's redaction helper for structured payloads and adds scoped filtering for `aiounifi` plus this integration's loggers. It also summarizes raw response bodies, redacts JSON websocket payloads, hides controller URL authorities, and removes device identity details from LED discovery logs.

Fixes sirkirby/unifi-network-rules#149.

## Testing

- `make lint`
- `make test` (`134 passed`)
- Live Home Assistant verification on a local Home Assistant instance: enabled debug logging, triggered `unifi_network_rules.refresh`, scanned 1,227 post-restart debug lines, then restored log levels to warning. The scan found zero matches for the old warning, HA credentials/token, cookies, CSRF headers, raw response bodies, IPs, MACs, unredacted controller URLs, or `unr_*` entity IDs.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)