### PR TITLE
feat: add funding information and sponsorship options to support project

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: sirkirby
+custom:
+  - "https://github.com/sirkirby/unifi-network-rules/blob/main/FUNDING.md"

--- a/FUNDING.md
+++ b/FUNDING.md
@@ -1,0 +1,37 @@
+# Sponsor UniFi Network Rules
+
+UniFi Network Rules is an independent custom integration for Home Assistant. It helps Home Assistant users manage UniFi firewall policies, traffic rules, port forwards, static routes, NAT rules, QoS rules, VPN configuration, WLANs, and other controller-backed settings from automations and switch entities.
+
+If this integration saves you time or makes your home lab easier to manage, sponsorship helps keep it maintained.
+
+## What Sponsorship Funds
+
+Sponsorship goes toward the recurring work that keeps this integration reliable as both Home Assistant and UniFi Network continue to change:
+
+- Home Assistant compatibility work across new core releases, validation changes, and HACS expectations.
+- Live UniFi controller testing for API behavior, firmware changes, and controller edge cases.
+- AI-assisted development, review, test generation, release notes, and maintenance work.
+- Release maintenance, issue triage, docs, examples, diagnostics, and security hardening.
+- Regression testing for high-risk rule types such as firewall policies, NAT rules, routes, VPNs, and port forwards.
+
+## Support Options
+
+GitHub Sponsors is the project funding path:
+
+Choose the matching tier on GitHub Sponsors:
+
+- [Supporter - $5/month](https://github.com/sponsors/sirkirby?metadata_project=unifi_network_rules&metadata_tier=monthly_5): helps keep compatibility fixes, docs, and issue triage moving.
+- [Power user - $15/month](https://github.com/sponsors/sirkirby?metadata_project=unifi_network_rules&metadata_tier=monthly_15): helps cover recurring AI and live-controller maintenance costs.
+- [Homelab / team backer - $50/month](https://github.com/sponsors/sirkirby?metadata_project=unifi_network_rules&metadata_tier=monthly_50): for power users, homelabs, and teams relying on this integration.
+- [One-time or custom support](https://github.com/sponsors/sirkirby?metadata_project=unifi_network_rules&metadata_tier=custom): for larger contributions, company support, or targeted compatibility work.
+
+## Project Boundaries
+
+Sponsorship supports maintenance, but it does not change the project's safety or governance boundaries:
+
+- The integration remains open source.
+- Core features are not paywalled.
+- Sponsors do not bypass compatibility checks, Home Assistant review standards, or safe rule-handling patterns.
+- Feature priorities still follow user impact, controller safety, maintainability, and the realities of the UniFi API.
+
+Thank you for helping sustain the project.

--- a/README.md
+++ b/README.md
@@ -8,13 +8,12 @@
 [![issues][issues-shield]][issues-link]
 [![validate-badge]][validate-workflow]
 
-[!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/sirkirby)
-
 UniFi Network Rules is a custom integration for Home Assistant that integrates with your UniFi Dream Machine/Router to both provide and help you create useful interactions and automations for your Home Lab. The goal of this integration is to simplify policy and rule management for real world use cases. I built this because I wanted to unlock the power of my UniFi firewall. From simple things like screen time and game server access controls for my kids, to more advanced like getting notified when a critical rule is changed and automatically backing up your rules. And most importantly, make all of this easy to use and share with anyone in your home or home lab. I hope you find it useful!
 
 > 📖 **[Quick Start Guide](QUICKSTART.md)** — Installation, setup, and troubleshooting
 > 🤝 **[Contributing](CONTRIBUTING.md)** — Development setup and PR workflow
 > 🔒 **[Security](SECURITY.md)** — Vulnerability reporting policy
+> 💗 **[Sponsor](https://github.com/sponsors/sirkirby)** — Support maintenance, Home Assistant compatibility, UniFi API testing, and releases. See [what sponsorship funds](FUNDING.md).
 
 ## What this integration provides
 


### PR DESCRIPTION
This pull request introduces project sponsorship options for UniFi Network Rules and updates related documentation to reflect the new funding model. The main changes include adding a detailed sponsorship guide, updating the README with sponsorship information, and linking GitHub Sponsors in the project configuration.

**Sponsorship and Documentation Updates:**

* Added a comprehensive `FUNDING.md` file describing sponsorship tiers, use of funds, and project boundaries.
* Updated the `README.md` to remove the "Buy Me A Coffee" button and add a section promoting GitHub Sponsors with a link to the new funding guide.

**Project Funding Configuration:**

* Configured `.github/FUNDING.yml` to point to the maintainer's GitHub Sponsors page and the custom funding guide.