### PR TITLE
fix: stop OON policies churning as ghost deletions on UniFi 10.x (#154)

### DIFF
--- a/custom_components/unifi_network_rules/coordination/entity_manager.py
+++ b/custom_components/unifi_network_rules/coordination/entity_manager.py
@@ -352,23 +352,12 @@ class CoordinatorEntityManager:
 
         current_known_ids = set(self.coordinator.known_unique_ids)  # Take a snapshot
 
-        # Gather ALL unique IDs present in the new data
+        # Gather ALL unique IDs present in the new data. Mirrors the discovery
+        # map so any rule type the discovery side creates entities for is also
+        # checked here — otherwise entries in known_unique_ids for missing
+        # types get flagged as ghost deletions every cycle (issue #154).
         all_current_unique_ids = set()
-        all_rule_sources_types = [
-            "port_forwards",
-            "traffic_routes",
-            "static_routes",
-            "nat_rules",
-            "firewall_policies",
-            "traffic_rules",
-            "legacy_firewall_rules",
-            "qos_rules",
-            "wlans",
-            "vpn_clients",
-            "vpn_servers",
-            "port_profiles",
-            "networks",
-        ]
+        all_rule_sources_types = [rule_type for rule_type, _ in self._rule_type_entity_map]
 
         for rule_type in all_rule_sources_types:
             rules = new_data.get(rule_type, [])

--- a/custom_components/unifi_network_rules/coordination/state_manager.py
+++ b/custom_components/unifi_network_rules/coordination/state_manager.py
@@ -68,6 +68,7 @@ class CoordinatorStateManager:
             "port_profiles",
             "networks",
             "nat_rules",
+            "oon_policies",
         ]:
             prev_count = len(previous_data.get(rule_type, []))
             new_count = len(new_data.get(rule_type, []))
@@ -87,6 +88,7 @@ class CoordinatorStateManager:
             "wlans",
             "qos_rules",
             "nat_rules",
+            "oon_policies",
         ]:
             prev_rules = previous_data.get(rule_type, [])
             new_rules = new_data.get(rule_type, [])
@@ -286,6 +288,7 @@ class CoordinatorStateManager:
                 "networks",
                 "devices",
                 "nat_rules",
+                "oon_policies",
             ]
         )
 

--- a/custom_components/unifi_network_rules/manifest.json
+++ b/custom_components/unifi_network_rules/manifest.json
@@ -12,7 +12,7 @@
     "quality_scale": "custom",
     "requirements": [
         "aiohttp",
-        "aiounifi>=87.0.0",
+        "aiounifi>=91",
         "orjson>=3.8.0"
     ],
     "version": "4.4.5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ asyncio
 aiofiles
 aiohttp
 argparse
-aiounifi>=87.0.0
+aiounifi>=91
 pytest
 pytest-asyncio
 pytest-aiohttp

--- a/tests/test_oon_policy.py
+++ b/tests/test_oon_policy.py
@@ -273,3 +273,28 @@ class TestOONPolicyIntegration:
         detector = UnifiedChangeDetector(Mock(), Mock())
         assert "oon_policies" in detector._rule_type_mapping
         assert detector._rule_type_mapping["oon_policies"] == "oon_policy"
+
+    def test_deletion_check_does_not_orphan_oon_policies(self, oon_policy_payload):
+        """Regression for #154: OON policies present in current data must not
+        be flagged as deletions every cycle. The deletion-check iteration list
+        previously omitted "oon_policies", causing every OON ID in
+        known_unique_ids to be treated as a ghost deletion on every poll."""
+        from custom_components.unifi_network_rules.coordination.entity_manager import (
+            CoordinatorEntityManager,
+        )
+        from custom_components.unifi_network_rules.helpers.rule import get_rule_id
+
+        policy = OONPolicy(oon_policy_payload)
+        oon_unique_id = get_rule_id(policy)
+        assert oon_unique_id and oon_unique_id.startswith("unr_oon_")
+
+        coordinator = Mock()
+        coordinator._initial_update_done = True
+        coordinator.known_unique_ids = {oon_unique_id}
+
+        manager = CoordinatorEntityManager(Mock(), coordinator)
+        manager._process_deleted_rules = Mock()
+
+        manager.check_for_deleted_rules({"oon_policies": [policy]})
+
+        manager._process_deleted_rules.assert_not_called()


### PR DESCRIPTION
Fixes #154.

## Summary

- **Root cause:** `check_for_deleted_rules` in `coordination/entity_manager.py` iterated a hard-coded list of rule types when building the set of "currently present" unique IDs. The list never had `"oon_policies"` added, so on UniFi 10.x controllers every `unr_oon_*` ID in `known_unique_ids` looked "missing" from current data on every poll. The 25%-mass-deletion safety capped removal at 5, those 5 were then re-discovered and recreated the next cycle — producing the forever-churn + "Large number of various_orphaned deletions" warnings the user reported.
- **Fix:** Derive `all_rule_sources_types` directly from `_rule_type_entity_map` (the discovery side's source of truth) so the two cannot drift again as new rule types are added.
- **Secondary drift:** Two analogous lists in `coordination/state_manager.py` (smart-polling change detection + data-valid sanity check) also omitted `oon_policies`. Added it there too.
- **Dependency:** Bumped `aiounifi` floor from `>=87.0.0` to `>=91` to match the version pinned by Home Assistant Core's bundled `unifi` integration. No code changes required for the bump.

The OON duplicate filter (`_filter_oon_policy_duplicates`) is unrelated — it works correctly and stays as-is. The user's hypothesis identified the right area but the wrong mechanism.

## Test plan

- [x] New regression test `test_deletion_check_does_not_orphan_oon_policies` reproduces the exact symptom from #154 and fails against `main` (`AssertionError: Expected 'mock' to not have been called. Called 1 times. Calls: [call('various_orphaned', {'unr_oon_…'}, 1)]`).
- [x] Full suite: 135 passed.
- [x] Dogfooded on a live HA Core install with the integration loaded — no startup errors, no import errors against `aiounifi>=91`, all 14 rule-source fetches (including the new `oon_policies` path) execute cleanly. This particular controller has 0 OON policies so the bug can't manifest there directly; the regression test covers the OON-present path.
- [ ] Awaiting user-side confirmation on the reporter's UniFi 10.x controller (12 OON policies) that the cycle no longer triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)